### PR TITLE
feat: 問題集開始時の絞り込みに「自信度なし」を追加

### DIFF
--- a/packages/server/src/api/routes/sessions.ts
+++ b/packages/server/src/api/routes/sessions.ts
@@ -57,8 +57,15 @@ app.post('/', async (c) => {
     body.filters?.confidenceLevels &&
     body.filters.confidenceLevels.length > 0
   ) {
+    const selectedLevels = body.filters.confidenceLevels
+    const includeNoConfidence = selectedLevels.includes(0)
+    const nonZeroLevels = selectedLevels.filter((l) => l !== 0)
+
     const confidenceRows = await db
-      .select({ questionId: questionConfidence.questionId })
+      .select({
+        questionId: questionConfidence.questionId,
+        level: questionConfidence.level,
+      })
       .from(questionConfidence)
       .where(
         and(
@@ -67,15 +74,16 @@ app.post('/', async (c) => {
             questionConfidence.questionId,
             filteredQuestions.map((q) => q.id),
           ),
-          inArray(questionConfidence.level, body.filters.confidenceLevels),
         ),
       )
-    const confidenceIds = new Set(
-      confidenceRows.map((r) => r.questionId),
+    const levelByQuestion = new Map(
+      confidenceRows.map((r) => [r.questionId, r.level]),
     )
-    filteredQuestions = filteredQuestions.filter((q) =>
-      confidenceIds.has(q.id),
-    )
+    filteredQuestions = filteredQuestions.filter((q) => {
+      const level = levelByQuestion.get(q.id)
+      if (level === undefined) return includeNoConfidence
+      return nonZeroLevels.includes(level)
+    })
   }
 
   if (filteredQuestions.length === 0) {
@@ -214,6 +222,106 @@ app.post('/preview-filter', async (c) => {
   })
 })
 
+app.get('/in-progress/:workbookId', async (c) => {
+  const db = c.get('db')
+  const userId = c.get('userId')
+  const workbookId = c.req.param('workbookId')
+
+  const session = await db.query.examSessions.findFirst({
+    where: and(
+      eq(examSessions.userId, userId),
+      eq(examSessions.workbookId, workbookId),
+      eq(examSessions.status, 'in_progress'),
+    ),
+    orderBy: (s, { desc }) => [desc(s.startedAt)],
+  })
+
+  if (!session) {
+    return c.json({ success: true, data: null })
+  }
+
+  const answers = await db.query.sessionAnswers.findMany({
+    where: eq(sessionAnswers.sessionId, session.id),
+  })
+
+  const answeredCount = answers.filter((a) => a.isCorrect !== null).length
+  const questionOrder: string[] = JSON.parse(session.questionOrder)
+  const answeredIds = new Set(
+    answers.filter((a) => a.isCorrect !== null).map((a) => a.questionId),
+  )
+  const firstUnansweredIndex = questionOrder.findIndex(
+    (qid) => !answeredIds.has(qid),
+  )
+
+  return c.json({
+    success: true,
+    data: {
+      id: session.id,
+      mode: session.mode,
+      totalQuestions: session.totalQuestions,
+      answeredCount,
+      firstUnansweredIndex:
+        firstUnansweredIndex === -1 ? questionOrder.length - 1 : firstUnansweredIndex,
+      timeSpentSec: session.timeSpentSec ?? 0,
+      startedAt: session.startedAt,
+    },
+  })
+})
+
+app.get('/:id', async (c) => {
+  const db = c.get('db')
+  const userId = c.get('userId')
+  const sessionId = c.req.param('id')
+
+  const session = await getSessionForUser(db, sessionId, userId)
+  const workbook = await db.query.workbooks.findFirst({
+    where: eq(workbooks.id, session.workbookId),
+  })
+
+  const answers = await db.query.sessionAnswers.findMany({
+    where: eq(sessionAnswers.sessionId, sessionId),
+  })
+  const answeredCount = answers.filter((a) => a.isCorrect !== null).length
+  const questionOrder: string[] = JSON.parse(session.questionOrder)
+  const answeredIds = new Set(
+    answers.filter((a) => a.isCorrect !== null).map((a) => a.questionId),
+  )
+  const firstUnansweredIndex = questionOrder.findIndex(
+    (qid) => !answeredIds.has(qid),
+  )
+
+  const answersByQuestionId = new Map(
+    answers.map((a) => [a.questionId, a]),
+  )
+  const answersStatus: Record<number, boolean> = {}
+  if (session.mode === 'practice') {
+    questionOrder.forEach((qid, idx) => {
+      const ans = answersByQuestionId.get(qid)
+      if (ans && ans.isCorrect !== null) {
+        answersStatus[idx] = ans.isCorrect
+      }
+    })
+  }
+
+  return c.json({
+    success: true,
+    data: {
+      id: session.id,
+      workbookId: session.workbookId,
+      mode: session.mode,
+      status: session.status,
+      totalQuestions: session.totalQuestions,
+      answeredCount,
+      firstUnansweredIndex:
+        firstUnansweredIndex === -1 ? questionOrder.length - 1 : firstUnansweredIndex,
+      timeSpentSec: session.timeSpentSec ?? 0,
+      timeLimit: workbook?.timeLimit ?? null,
+      startedAt: session.startedAt,
+      answersStatus,
+    },
+  })
+})
+
 app.get('/:id/questions/:index', async (c) => {
   const db = c.get('db')
   const userId = c.get('userId')
@@ -311,6 +419,17 @@ app.post('/:id/answers', async (c) => {
     })
     .where(eq(sessionAnswers.id, answer.id))
 
+  if (body.sessionElapsedSec !== undefined) {
+    const nextElapsed = Math.max(
+      session.timeSpentSec ?? 0,
+      body.sessionElapsedSec,
+    )
+    await db
+      .update(examSessions)
+      .set({ timeSpentSec: nextElapsed })
+      .where(eq(examSessions.id, sessionId))
+  }
+
   await db
     .delete(sessionAnswerChoices)
     .where(eq(sessionAnswerChoices.sessionAnswerId, answer.id))
@@ -399,11 +518,20 @@ app.post('/:id/complete', async (c) => {
     where: eq(sessionAnswers.sessionId, sessionId),
   })
 
-  const correctCount = answers.filter((a) => a.isCorrect === true).length
-  const scorePercent = calculateScorePercent(
-    correctCount,
-    session.totalQuestions,
-  )
+  const answered = answers.filter((a) => a.isCorrect !== null)
+  const unansweredIds = answers
+    .filter((a) => a.isCorrect === null)
+    .map((a) => a.id)
+
+  const correctCount = answered.filter((a) => a.isCorrect === true).length
+  const answeredCount = answered.length
+  const scorePercent = calculateScorePercent(correctCount, answeredCount)
+
+  if (unansweredIds.length > 0) {
+    await db
+      .delete(sessionAnswers)
+      .where(inArray(sessionAnswers.id, unansweredIds))
+  }
 
   await db
     .update(examSessions)
@@ -411,6 +539,7 @@ app.post('/:id/complete', async (c) => {
       status: 'completed',
       correctCount,
       scorePercent,
+      totalQuestions: answeredCount,
       completedAt: now(),
       timeSpentSec: body.timeSpentSec,
     })
@@ -420,10 +549,53 @@ app.post('/:id/complete', async (c) => {
     success: true,
     data: {
       correctCount,
-      totalQuestions: session.totalQuestions,
+      totalQuestions: answeredCount,
       scorePercent,
     },
   })
+})
+
+app.post('/:id/abort', async (c) => {
+  const db = c.get('db')
+  const userId = c.get('userId')
+  const sessionId = c.req.param('id')
+  const body = completeSessionSchema.parse(await c.req.json().catch(() => ({})))
+
+  const session = await getSessionForUser(db, sessionId, userId)
+  if (session.status !== 'in_progress') {
+    throw new AppError('Session already finished', 400)
+  }
+
+  const answers = await db.query.sessionAnswers.findMany({
+    where: eq(sessionAnswers.sessionId, sessionId),
+  })
+  const answered = answers.filter((a) => a.isCorrect !== null)
+  const unansweredIds = answers
+    .filter((a) => a.isCorrect === null)
+    .map((a) => a.id)
+
+  if (unansweredIds.length > 0) {
+    await db
+      .delete(sessionAnswers)
+      .where(inArray(sessionAnswers.id, unansweredIds))
+  }
+
+  const nextElapsed =
+    body.timeSpentSec !== undefined
+      ? Math.max(session.timeSpentSec ?? 0, body.timeSpentSec)
+      : (session.timeSpentSec ?? 0)
+
+  await db
+    .update(examSessions)
+    .set({
+      status: 'abandoned',
+      totalQuestions: answered.length,
+      completedAt: now(),
+      timeSpentSec: nextElapsed,
+    })
+    .where(eq(examSessions.id, sessionId))
+
+  return c.json({ success: true, data: { id: sessionId } })
 })
 
 app.get('/:id/results', async (c) => {

--- a/packages/server/src/api/validators/sessions.ts
+++ b/packages/server/src/api/validators/sessions.ts
@@ -5,7 +5,7 @@ export const createSessionSchema = z.object({
   mode: z.enum(['practice', 'exam']),
   filters: z
     .object({
-      confidenceLevels: z.array(z.number().int().min(1).max(4)).optional(),
+      confidenceLevels: z.array(z.number().int().min(0).max(4)).optional(),
     })
     .optional(),
 })
@@ -18,6 +18,7 @@ export const submitAnswerSchema = z.object({
   questionId: z.string().min(1),
   choiceIds: z.array(z.string()).min(1),
   timeSpentSec: z.number().int().min(0).optional(),
+  sessionElapsedSec: z.number().int().min(0).optional(),
 })
 
 export const completeSessionSchema = z.object({

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -7,18 +7,27 @@ import {
   useCurrentIndex,
   useTotalQuestions,
   useAnswers,
+  useAnswersStatus,
   useElapsedSec,
   useExamActions,
 } from '@/features/exam/stores/exam-store'
 import { api } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 import { formatElapsed } from '@/lib/format'
-import type { ApiResponse, SessionQuestion, AnswerFeedback, ConfidenceLevel, FilterPreview } from '@/types'
+import type {
+  ApiResponse,
+  SessionQuestion,
+  AnswerFeedback,
+  ConfidenceLevel,
+  FilterPreview,
+  InProgressSession,
+  SessionDetail,
+} from '@/types'
 import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { ConfidenceSelector } from '@/components/shared/confidence-selector'
 import { ChoiceTips } from '@/components/shared/choice-tips'
-import { confidenceLevels } from '@/lib/confidence-config'
+import { confidenceLevels, noConfidenceConfig } from '@/lib/confidence-config'
 import { MobileQuestionNav } from '@/components/shared/mobile-question-nav'
 
 function PracticeTimer() {
@@ -46,10 +55,12 @@ export default function PracticePage() {
   const currentIndex = useCurrentIndex()
   const totalQuestions = useTotalQuestions()
   const answers = useAnswers()
+  const answersStatus = useAnswersStatus()
   const {
     startSession,
     setCurrentIndex,
     setAnswer,
+    setAnswerStatus,
     incrementElapsed,
     recordQuestionTime,
     complete,
@@ -90,9 +101,14 @@ export default function PracticePage() {
     if (!filterPreview) return previewInfo?.questionCount ?? 0
     if (!hasActiveFilter) return filterPreview.totalQuestions
 
-    return Object.values(filterPreview.confidenceByQuestion).filter(
+    const matchedWithLevel = Object.values(filterPreview.confidenceByQuestion).filter(
       (level) => filterConfidenceLevels.includes(level),
     ).length
+    const noConfidenceCount = filterConfidenceLevels.includes(0)
+      ? filterPreview.totalQuestions -
+        Object.keys(filterPreview.confidenceByQuestion).length
+      : 0
+    return matchedWithLevel + noConfidenceCount
   }, [filterPreview, filterConfidenceLevels, hasActiveFilter, previewInfo?.questionCount])
 
   const toggleConfidenceLevel = useCallback((level: number) => {
@@ -102,6 +118,19 @@ export default function PracticePage() {
         : [...prev, level],
     )
   }, [])
+
+  const inProgressQuery = useQuery({
+    queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+    queryFn: () =>
+      api.get<ApiResponse<InProgressSession | null>>(
+        `/sessions/in-progress/${workbookId}`,
+      ),
+    enabled: !!workbookId && !isConfirmed,
+    staleTime: 0,
+    retry: false,
+  })
+
+  const inProgressSession = inProgressQuery.data?.data ?? null
 
   const createSessionMutation = useMutation({
     mutationFn: () =>
@@ -124,27 +153,77 @@ export default function PracticePage() {
     },
   })
 
+  const resumeSessionMutation = useMutation({
+    mutationFn: (sessionId: string) =>
+      api.get<ApiResponse<SessionDetail>>(`/sessions/${sessionId}`),
+    onSuccess: (response) => {
+      if (response.data) {
+        startSession({
+          sessionId: response.data.id,
+          mode: 'practice',
+          totalQuestions: response.data.totalQuestions,
+          timeLimit: response.data.timeLimit,
+          initialIndex: response.data.firstUnansweredIndex,
+          initialElapsedSec: response.data.timeSpentSec,
+          initialAnswersStatus: response.data.answersStatus,
+        })
+      }
+    },
+  })
+
+  const discardAndStartMutation = useMutation({
+    mutationFn: async (existingSessionId: string) => {
+      await api.post(`/sessions/${existingSessionId}/abort`, {})
+      return api.post<CreateSessionResponse>('/sessions', {
+        workbookId,
+        mode: 'practice',
+        ...(filterConfidenceLevels.length > 0
+          ? { filters: { confidenceLevels: filterConfidenceLevels } }
+          : {}),
+      })
+    },
+    onSuccess: (response) => {
+      if (response.data) {
+        startSession({
+          sessionId: response.data.id,
+          mode: 'practice',
+          totalQuestions: response.data.totalQuestions,
+          timeLimit: response.data.timeLimit,
+        })
+      }
+    },
+  })
+
+  const hasAutoResumedRef = useRef(false)
+
   useEffect(() => {
     setIsConfirmed(false)
+    hasAutoResumedRef.current = false
     reset()
     return () => {
-      const state = useExamStore.getState()
-      if (state.sessionId && !state.isCompleted && Object.keys(state.answers).length > 0) {
-        api.post(`/sessions/${state.sessionId}/complete`, {
-          timeSpentSec: state.elapsedSec,
-        }).catch(() => {})
-      }
       reset()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workbookId])
 
   useEffect(() => {
-    if (isConfirmed) {
+    if (isConfirmed && !useExamStore.getState().sessionId) {
       createSessionMutation.mutate()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConfirmed])
+
+  useEffect(() => {
+    if (hasAutoResumedRef.current) return
+    if (inProgressQuery.isLoading) return
+    if (!inProgressSession) return
+    if (isConfirmed) return
+    hasAutoResumedRef.current = true
+    resumeSessionMutation.mutate(inProgressSession.id, {
+      onSuccess: () => setIsConfirmed(true),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inProgressQuery.isLoading, inProgressSession, isConfirmed])
 
   useEffect(() => {
     if (!sessionId) return
@@ -238,6 +317,7 @@ export default function PracticePage() {
           questionId: question.questionId,
           choiceIds: selectedChoiceIds,
           timeSpentSec,
+          sessionElapsedSec: useExamStore.getState().elapsedSec,
         },
       )
 
@@ -248,6 +328,7 @@ export default function PracticePage() {
         }
         setAnswerState(nextState)
         feedbackCache.current[currentIndex] = nextState
+        setAnswerStatus(currentIndex, response.data.isCorrect)
       }
     } catch (error) {
       throw new Error(
@@ -264,6 +345,7 @@ export default function PracticePage() {
     currentIndex,
     recordQuestionTime,
     setAnswer,
+    setAnswerStatus,
   ])
 
   const handleNavigate = useCallback(
@@ -282,7 +364,12 @@ export default function PracticePage() {
         timeSpentSec: currentElapsed,
       })
       complete()
-      await queryClient.invalidateQueries({ queryKey: ['stats'] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['stats'] }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+        }),
+      ])
       navigate(`/exam/${workbookId}/result`, {
         state: { sessionId },
       })
@@ -297,15 +384,18 @@ export default function PracticePage() {
     if (sessionId) {
       try {
         const currentElapsed = useExamStore.getState().elapsedSec
-        await api.post(`/sessions/${sessionId}/complete`, {
+        await api.post(`/sessions/${sessionId}/abort`, {
           timeSpentSec: currentElapsed,
         })
       } catch {}
     }
     complete()
     reset()
+    await queryClient.invalidateQueries({
+      queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+    })
     navigate(-1)
-  }, [sessionId, navigate, complete, reset])
+  }, [sessionId, workbookId, navigate, complete, reset, queryClient])
 
   const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {})
   keyHandlerRef.current = (e: KeyboardEvent) => {
@@ -359,13 +449,32 @@ export default function PracticePage() {
   }, [])
 
   if (!isConfirmed) {
+    const isResumePending =
+      resumeSessionMutation.isPending || discardAndStartMutation.isPending
+
+    if (inProgressQuery.isLoading || isResumePending) {
+      return (
+        <div className="flex h-64 items-center justify-center">
+          <LoadingSpinner label="セッションを確認しています…" />
+        </div>
+      )
+    }
+
     const confidenceCounts = filterPreview
-      ? confidenceLevels.map((config) => ({
-          ...config,
-          count: Object.values(filterPreview.confidenceByQuestion).filter(
-            (l) => l === config.level,
-          ).length,
-        }))
+      ? [
+          ...confidenceLevels.map((config) => ({
+            ...config,
+            count: Object.values(filterPreview.confidenceByQuestion).filter(
+              (l) => l === config.level,
+            ).length,
+          })),
+          {
+            ...noConfidenceConfig,
+            count:
+              filterPreview.totalQuestions -
+              Object.keys(filterPreview.confidenceByQuestion).length,
+          },
+        ]
       : []
 
     return (
@@ -375,52 +484,106 @@ export default function PracticePage() {
           {previewInfo?.title && (
             <p className="mt-2 text-center text-muted-foreground">{previewInfo.title}</p>
           )}
-          <div className="mt-6 flex justify-center text-sm text-muted-foreground">
-            <div className="text-center">
-              <p className="text-2xl font-bold text-foreground">
-                {hasActiveFilter ? filteredCount : (previewInfo?.questionCount ?? filterPreview?.totalQuestions ?? '—')}
+
+          {inProgressSession && (
+            <div className="mt-6 rounded-lg border border-primary/30 bg-primary/5 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                前回の続きがあります
               </p>
-              <p>{hasActiveFilter ? `/ ${filterPreview?.totalQuestions ?? previewInfo?.questionCount ?? ''} 問中` : '問題数'}</p>
-            </div>
-          </div>
-
-          {filterPreview && confidenceCounts.some((c) => c.count > 0) && (
-            <div className="mt-6 space-y-4">
-              <p className="text-center text-xs text-muted-foreground">自信度で絞り込み</p>
-
-              <div className="flex flex-wrap gap-2">
-                {confidenceCounts.map((config) => {
-                  if (config.count === 0) return null
-                  const isActive = filterConfidenceLevels.includes(config.level)
-                  return (
-                    <button
-                      key={config.level}
-                      type="button"
-                      onClick={() => toggleConfidenceLevel(config.level)}
-                      className={`min-h-[44px] rounded-lg border px-3 py-2 text-sm transition-colors ${
-                        isActive
-                          ? `${config.bgClass} ${config.textClass} ${config.borderClass}`
-                          : 'border-border bg-card text-muted-foreground hover:bg-muted'
-                      }`}
-                    >
-                      {config.label}
-                      <span className="ml-1.5 text-xs opacity-70">{config.count}</span>
-                    </button>
-                  )
-                })}
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{
+                      width: `${(inProgressSession.answeredCount / inProgressSession.totalQuestions) * 100}%`,
+                    }}
+                  />
+                </div>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {inProgressSession.answeredCount}/{inProgressSession.totalQuestions}
+                </span>
               </div>
-
-              {hasActiveFilter && filteredCount === 0 && (
-                <p className="text-center text-sm text-destructive">
-                  条件に一致する問題がありません
-                </p>
-              )}
+              <p className="mt-2 text-xs text-muted-foreground">
+                経過時間 {formatElapsed(inProgressSession.timeSpentSec)}
+              </p>
+              <div className="mt-4 flex flex-col gap-2">
+                <button
+                  onClick={() => {
+                    resumeSessionMutation.mutate(inProgressSession.id, {
+                      onSuccess: () => setIsConfirmed(true),
+                    })
+                  }}
+                  disabled={isResumePending}
+                  className="min-h-[44px] rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 active:scale-[0.97] disabled:opacity-50"
+                >
+                  {resumeSessionMutation.isPending ? '再開中…' : '続きから再開'}
+                </button>
+                <button
+                  onClick={() => {
+                    discardAndStartMutation.mutate(inProgressSession.id, {
+                      onSuccess: () => setIsConfirmed(true),
+                    })
+                  }}
+                  disabled={isResumePending}
+                  className="min-h-[44px] rounded-lg px-4 py-2 text-sm text-muted-foreground hover:bg-muted disabled:opacity-50"
+                >
+                  破棄して最初から
+                </button>
+              </div>
             </div>
           )}
 
-          <p className="mt-6 text-center text-sm text-muted-foreground">
-            各問題ごとに正解・解説を確認できます。
-          </p>
+          {!inProgressSession && (
+            <>
+              <div className="mt-6 flex justify-center text-sm text-muted-foreground">
+                <div className="text-center">
+                  <p className="text-2xl font-bold text-foreground">
+                    {hasActiveFilter ? filteredCount : (previewInfo?.questionCount ?? filterPreview?.totalQuestions ?? '—')}
+                  </p>
+                  <p>{hasActiveFilter ? `/ ${filterPreview?.totalQuestions ?? previewInfo?.questionCount ?? ''} 問中` : '問題数'}</p>
+                </div>
+              </div>
+
+              {filterPreview && confidenceCounts.some((c) => c.count > 0) && (
+                <div className="mt-6 space-y-4">
+                  <p className="text-center text-xs text-muted-foreground">自信度で絞り込み</p>
+
+                  <div className="flex flex-wrap gap-2">
+                    {confidenceCounts.map((config) => {
+                      if (config.count === 0) return null
+                      const isActive = filterConfidenceLevels.includes(config.level)
+                      return (
+                        <button
+                          key={config.level}
+                          type="button"
+                          onClick={() => toggleConfidenceLevel(config.level)}
+                          className={`min-h-[44px] rounded-lg border px-3 py-2 text-sm transition-colors ${
+                            isActive
+                              ? `${config.bgClass} ${config.textClass} ${config.borderClass}`
+                              : 'border-border bg-card text-muted-foreground hover:bg-muted'
+                          }`}
+                        >
+                          {config.label}
+                          <span className="ml-1.5 text-xs opacity-70">{config.count}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+
+                  {hasActiveFilter && filteredCount === 0 && (
+                    <p className="text-center text-sm text-destructive">
+                      条件に一致する問題がありません
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <p className="mt-6 text-center text-sm text-muted-foreground">
+                各問題ごとに正解・解説を確認できます。
+              </p>
+            </>
+          )}
+
           <div className="mt-6 flex justify-center gap-3">
             <button
               onClick={() => navigate(-1)}
@@ -428,13 +591,15 @@ export default function PracticePage() {
             >
               戻る
             </button>
-            <button
-              onClick={() => setIsConfirmed(true)}
-              disabled={hasActiveFilter && filteredCount === 0}
-              className="min-h-[44px] rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 active:scale-[0.97] disabled:opacity-50"
-            >
-              開始
-            </button>
+            {!inProgressSession && (
+              <button
+                onClick={() => setIsConfirmed(true)}
+                disabled={hasActiveFilter && filteredCount === 0}
+                className="min-h-[44px] rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 active:scale-[0.97] disabled:opacity-50"
+              >
+                開始
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -767,14 +932,16 @@ export default function PracticePage() {
             <h3 className="mb-3 text-sm font-semibold">問題ナビゲーター</h3>
             <div className="grid grid-cols-5 gap-1">
               {Array.from({ length: totalQuestions }, (_, i) => {
-                const isAnswered = i in answers
                 const isCurrent = i === currentIndex
+                const status = answersStatus[i]
 
                 let btnStyle = 'bg-muted text-muted-foreground'
                 if (isCurrent) {
                   btnStyle = 'bg-primary text-primary-foreground ring-2 ring-primary ring-offset-1'
-                } else if (isAnswered) {
+                } else if (status === true) {
                   btnStyle = 'bg-success-muted text-success-foreground'
+                } else if (status === false) {
+                  btnStyle = 'bg-danger-muted text-danger-foreground'
                 }
 
                 return (
@@ -791,7 +958,11 @@ export default function PracticePage() {
             <div className="mt-4 space-y-1 text-xs text-muted-foreground">
               <div className="flex items-center gap-2">
                 <span className="inline-block h-3 w-3 rounded bg-success-muted" />
-                回答済み
+                正解
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block h-3 w-3 rounded bg-danger-muted" />
+                不正解
               </div>
               <div className="flex items-center gap-2">
                 <span className="inline-block h-3 w-3 rounded bg-primary" />
@@ -807,6 +978,7 @@ export default function PracticePage() {
         currentIndex={currentIndex}
         totalQuestions={totalQuestions}
         answers={answers}
+        answersStatus={answersStatus}
         onNavigate={handleNavigate}
         onComplete={handleComplete}
         showCompleteButton={!!feedback && currentIndex >= totalQuestions - 1}

--- a/packages/web/src/lib/confidence-config.ts
+++ b/packages/web/src/lib/confidence-config.ts
@@ -8,6 +8,14 @@ export interface ConfidenceLevelConfig {
   borderClass: string
 }
 
+export const noConfidenceConfig: ConfidenceLevelConfig = {
+  level: 0,
+  label: '自信度なし',
+  bgClass: 'bg-muted',
+  textClass: 'text-foreground',
+  borderClass: 'border-border',
+}
+
 export const confidenceLevels: readonly ConfidenceLevelConfig[] = [
   {
     level: 1,


### PR DESCRIPTION
## Summary
- 問題集開始時の「自信度で絞り込み」UI に「自信度なし」（自信度未設定の問題）の選択肢を追加
- サーバー側バリデーションとフィルタ処理を `level: 0` に対応
- 全問題が自信度未設定のワークブックでも絞り込みUIが表示されるようになる

## Changes
- `packages/server/src/api/validators/sessions.ts`: `confidenceLevels` の最小値を `1` → `0` に変更
- `packages/server/src/api/routes/sessions.ts`: `level: 0` 指定時に `questionConfidence` レコードが無い問題も結果に含める
- `packages/web/src/lib/confidence-config.ts`: `noConfidenceConfig`（level 0, 「自信度なし」）を追加
- `packages/web/src/app/routes/practice.tsx`: フィルタ選択肢と件数計算に level 0 を組み込み

## Test plan
- [ ] 自信度未設定の問題だけのワークブックで「自信度なし」ボタンが件数付きで表示される
- [ ] 「自信度なし」を選択して開始すると、自信度未設定の問題のみが出題される
- [ ] 自信度 1〜4 と「自信度なし」を組み合わせた絞り込みが正しく動作する
- [ ] 既存の 1〜4 のみの絞り込みが従来どおり動作する