### PR TITLE
fix: 演習画面のビルド依存を追加（PR#1の型エラー修正）

### DIFF
--- a/packages/web/src/app/routes/exam.tsx
+++ b/packages/web/src/app/routes/exam.tsx
@@ -14,7 +14,12 @@ import {
 import { api } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 import { formatCountdown, formatElapsed } from '@/lib/format'
-import type { ApiResponse, SessionQuestion } from '@/types'
+import type {
+  ApiResponse,
+  SessionQuestion,
+  InProgressSession,
+  SessionDetail,
+} from '@/types'
 import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { MobileQuestionNav } from '@/components/shared/mobile-question-nav'
@@ -88,6 +93,19 @@ export default function ExamPage() {
   const [showAbortConfirm, setShowAbortConfirm] = useState(false)
   const previewInfo = location.state as { title?: string; questionCount?: number; timeLimit?: number | null } | null
 
+  const inProgressQuery = useQuery({
+    queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+    queryFn: () =>
+      api.get<ApiResponse<InProgressSession | null>>(
+        `/sessions/in-progress/${workbookId}`,
+      ),
+    enabled: !!workbookId && !isConfirmed,
+    staleTime: 0,
+    retry: false,
+  })
+
+  const inProgressSession = inProgressQuery.data?.data ?? null
+
   const createSessionMutation = useMutation({
     mutationFn: () =>
       api.post<CreateSessionResponse>('/sessions', {
@@ -106,27 +124,73 @@ export default function ExamPage() {
     },
   })
 
+  const resumeSessionMutation = useMutation({
+    mutationFn: (id: string) =>
+      api.get<ApiResponse<SessionDetail>>(`/sessions/${id}`),
+    onSuccess: (response) => {
+      if (response.data) {
+        startSession({
+          sessionId: response.data.id,
+          mode: 'exam',
+          totalQuestions: response.data.totalQuestions,
+          timeLimit: response.data.timeLimit,
+          initialIndex: response.data.firstUnansweredIndex,
+          initialElapsedSec: response.data.timeSpentSec,
+        })
+      }
+    },
+  })
+
+  const discardAndStartMutation = useMutation({
+    mutationFn: async (existingSessionId: string) => {
+      await api.post(`/sessions/${existingSessionId}/abort`, {})
+      return api.post<CreateSessionResponse>('/sessions', {
+        workbookId,
+        mode: 'exam',
+      })
+    },
+    onSuccess: (response) => {
+      if (response.data) {
+        startSession({
+          sessionId: response.data.id,
+          mode: 'exam',
+          totalQuestions: response.data.totalQuestions,
+          timeLimit: response.data.timeLimit,
+        })
+      }
+    },
+  })
+
+  const hasAutoResumedRef = useRef(false)
+
   useEffect(() => {
     setIsConfirmed(false)
+    hasAutoResumedRef.current = false
     reset()
     return () => {
-      const state = useExamStore.getState()
-      if (state.sessionId && !state.isCompleted && Object.keys(state.answers).length > 0) {
-        api.post(`/sessions/${state.sessionId}/complete`, {
-          timeSpentSec: state.elapsedSec,
-        }).catch(() => {})
-      }
       reset()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workbookId])
 
   useEffect(() => {
-    if (isConfirmed) {
+    if (isConfirmed && !useExamStore.getState().sessionId) {
       createSessionMutation.mutate()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConfirmed])
+
+  useEffect(() => {
+    if (hasAutoResumedRef.current) return
+    if (inProgressQuery.isLoading) return
+    if (!inProgressSession) return
+    if (isConfirmed) return
+    hasAutoResumedRef.current = true
+    resumeSessionMutation.mutate(inProgressSession.id, {
+      onSuccess: () => setIsConfirmed(true),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inProgressQuery.isLoading, inProgressSession, isConfirmed])
 
   useEffect(() => {
     if (!sessionId) return
@@ -153,7 +217,12 @@ export default function ExamPage() {
         timeSpentSec: currentElapsed,
       })
       complete()
-      await queryClient.invalidateQueries({ queryKey: ['stats'] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['stats'] }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+        }),
+      ])
       navigate(`/exam/${workbookId}/result`, {
         state: { sessionId },
       })
@@ -168,15 +237,18 @@ export default function ExamPage() {
     if (sessionId) {
       try {
         const currentElapsed = useExamStore.getState().elapsedSec
-        await api.post(`/sessions/${sessionId}/complete`, {
+        await api.post(`/sessions/${sessionId}/abort`, {
           timeSpentSec: currentElapsed,
         })
       } catch {}
     }
     complete()
     reset()
+    await queryClient.invalidateQueries({
+      queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
+    })
     navigate(-1)
-  }, [sessionId, navigate, complete, reset])
+  }, [sessionId, workbookId, navigate, complete, reset, queryClient])
 
   const elapsedSec = useElapsedSec()
 
@@ -263,6 +335,7 @@ export default function ExamPage() {
           questionId: question.questionId,
           choiceIds: selectedChoiceIds,
           timeSpentSec,
+          sessionElapsedSec: useExamStore.getState().elapsedSec,
         },
       )
     } catch (error) {
@@ -340,6 +413,17 @@ export default function ExamPage() {
   }, [])
 
   if (!isConfirmed) {
+    const isResumePending =
+      resumeSessionMutation.isPending || discardAndStartMutation.isPending
+
+    if (inProgressQuery.isLoading || isResumePending) {
+      return (
+        <div className="flex h-64 items-center justify-center">
+          <LoadingSpinner label="セッションを確認しています…" />
+        </div>
+      )
+    }
+
     return (
       <div className="mx-auto max-w-lg p-4">
         <div className="rounded-lg border bg-card p-8">
@@ -347,25 +431,79 @@ export default function ExamPage() {
           {previewInfo?.title && (
             <p className="mt-2 text-center text-muted-foreground">{previewInfo.title}</p>
           )}
-          {(previewInfo?.questionCount != null || previewInfo?.timeLimit != null) && (
-            <div className="mt-6 flex justify-center gap-8 text-sm text-muted-foreground">
-              {previewInfo.questionCount != null && (
-                <div className="text-center">
-                  <p className="text-2xl font-bold text-foreground">{previewInfo.questionCount}</p>
-                  <p>問題数</p>
+
+          {inProgressSession && (
+            <div className="mt-6 rounded-lg border border-primary/30 bg-primary/5 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                前回の続きがあります
+              </p>
+              <div className="mt-3 flex items-center gap-3">
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{
+                      width: `${(inProgressSession.answeredCount / inProgressSession.totalQuestions) * 100}%`,
+                    }}
+                  />
                 </div>
-              )}
-              {previewInfo.timeLimit != null && (
-                <div className="text-center">
-                  <p className="text-2xl font-bold text-foreground">{Math.floor(previewInfo.timeLimit / 60)}</p>
-                  <p>制限時間（分）</p>
-                </div>
-              )}
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {inProgressSession.answeredCount}/{inProgressSession.totalQuestions}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                経過時間 {formatElapsed(inProgressSession.timeSpentSec)}
+              </p>
+              <div className="mt-4 flex flex-col gap-2">
+                <button
+                  onClick={() => {
+                    resumeSessionMutation.mutate(inProgressSession.id, {
+                      onSuccess: () => setIsConfirmed(true),
+                    })
+                  }}
+                  disabled={isResumePending}
+                  className="min-h-[44px] rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 active:scale-[0.97] disabled:opacity-50"
+                >
+                  {resumeSessionMutation.isPending ? '再開中…' : '続きから再開'}
+                </button>
+                <button
+                  onClick={() => {
+                    discardAndStartMutation.mutate(inProgressSession.id, {
+                      onSuccess: () => setIsConfirmed(true),
+                    })
+                  }}
+                  disabled={isResumePending}
+                  className="min-h-[44px] rounded-lg px-4 py-2 text-sm text-muted-foreground hover:bg-muted disabled:opacity-50"
+                >
+                  破棄して最初から
+                </button>
+              </div>
             </div>
           )}
-          <p className="mt-6 text-center text-sm text-muted-foreground">
-            開始すると制限時間のカウントが始まります。
-          </p>
+
+          {!inProgressSession && (
+            <>
+              {(previewInfo?.questionCount != null || previewInfo?.timeLimit != null) && (
+                <div className="mt-6 flex justify-center gap-8 text-sm text-muted-foreground">
+                  {previewInfo.questionCount != null && (
+                    <div className="text-center">
+                      <p className="text-2xl font-bold text-foreground">{previewInfo.questionCount}</p>
+                      <p>問題数</p>
+                    </div>
+                  )}
+                  {previewInfo.timeLimit != null && (
+                    <div className="text-center">
+                      <p className="text-2xl font-bold text-foreground">{Math.floor(previewInfo.timeLimit / 60)}</p>
+                      <p>制限時間（分）</p>
+                    </div>
+                  )}
+                </div>
+              )}
+              <p className="mt-6 text-center text-sm text-muted-foreground">
+                開始すると制限時間のカウントが始まります。
+              </p>
+            </>
+          )}
+
           <div className="mt-6 flex justify-center gap-3">
             <button
               onClick={() => navigate(-1)}
@@ -373,12 +511,14 @@ export default function ExamPage() {
             >
               戻る
             </button>
-            <button
-              onClick={() => setIsConfirmed(true)}
-              className="min-h-[44px] rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              開始
-            </button>
+            {!inProgressSession && (
+              <button
+                onClick={() => setIsConfirmed(true)}
+                className="min-h-[44px] rounded-lg bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                開始
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/packages/web/src/components/shared/mobile-question-nav.tsx
+++ b/packages/web/src/components/shared/mobile-question-nav.tsx
@@ -5,6 +5,7 @@ interface MobileQuestionNavProps {
   currentIndex: number
   totalQuestions: number
   answers: Record<number, string[]>
+  answersStatus?: Record<number, boolean>
   onNavigate: (index: number) => void
   onComplete?: () => void
   showCompleteButton?: boolean
@@ -17,6 +18,7 @@ export function MobileQuestionNav({
   currentIndex,
   totalQuestions,
   answers,
+  answersStatus,
   onNavigate,
   onComplete,
   showCompleteButton,
@@ -70,11 +72,18 @@ export function MobileQuestionNav({
               {Array.from({ length: totalQuestions }, (_, i) => {
                 const isAnswered = i in answers
                 const isCurrent = i === currentIndex
+                const status = answersStatus?.[i]
 
                 let btnStyle = 'bg-muted text-muted-foreground'
                 if (isCurrent) {
                   btnStyle =
                     'bg-primary text-primary-foreground ring-2 ring-primary ring-offset-1'
+                } else if (status === true) {
+                  btnStyle =
+                    'bg-success-muted text-success-foreground'
+                } else if (status === false) {
+                  btnStyle =
+                    'bg-danger-muted text-danger-foreground'
                 } else if (isAnswered) {
                   btnStyle =
                     'bg-success-muted text-success-foreground'
@@ -98,11 +107,24 @@ export function MobileQuestionNav({
               })}
             </div>
 
-            <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
-              <div className="flex items-center gap-1.5">
-                <span className="inline-block h-3 w-3 rounded bg-success-muted" />
-                回答済み
-              </div>
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              {answersStatus ? (
+                <>
+                  <div className="flex items-center gap-1.5">
+                    <span className="inline-block h-3 w-3 rounded bg-success-muted" />
+                    正解
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="inline-block h-3 w-3 rounded bg-danger-muted" />
+                    不正解
+                  </div>
+                </>
+              ) : (
+                <div className="flex items-center gap-1.5">
+                  <span className="inline-block h-3 w-3 rounded bg-success-muted" />
+                  回答済み
+                </div>
+              )}
               <div className="flex items-center gap-1.5">
                 <span className="inline-block h-3 w-3 rounded bg-primary" />
                 現在

--- a/packages/web/src/features/exam/stores/exam-store.ts
+++ b/packages/web/src/features/exam/stores/exam-store.ts
@@ -7,6 +7,7 @@ type ExamState = {
   currentIndex: number
   totalQuestions: number
   answers: Record<number, string[]>
+  answersStatus: Record<number, boolean>
   timeLimit: number | null
   startedAt: number | null
   elapsedSec: number
@@ -20,9 +21,13 @@ type ExamActions = {
     mode: 'practice' | 'exam'
     totalQuestions: number
     timeLimit: number | null
+    initialIndex?: number
+    initialElapsedSec?: number
+    initialAnswersStatus?: Record<number, boolean>
   }) => void
   setCurrentIndex: (index: number) => void
   setAnswer: (index: number, choiceIds: string[]) => void
+  setAnswerStatus: (index: number, isCorrect: boolean) => void
   incrementElapsed: () => void
   recordQuestionTime: (index: number, seconds: number) => void
   complete: () => void
@@ -35,6 +40,7 @@ const initialState: ExamState = {
   currentIndex: 0,
   totalQuestions: 0,
   answers: {},
+  answersStatus: {},
   timeLimit: null,
   startedAt: null,
   elapsedSec: 0,
@@ -45,7 +51,15 @@ const initialState: ExamState = {
 export const useExamStore = create<ExamState & ExamActions>((set) => ({
   ...initialState,
 
-  startSession: ({ sessionId, mode, totalQuestions, timeLimit }) =>
+  startSession: ({
+    sessionId,
+    mode,
+    totalQuestions,
+    timeLimit,
+    initialIndex,
+    initialElapsedSec,
+    initialAnswersStatus,
+  }) =>
     set({
       ...initialState,
       sessionId,
@@ -53,6 +67,9 @@ export const useExamStore = create<ExamState & ExamActions>((set) => ({
       totalQuestions,
       timeLimit,
       startedAt: Date.now(),
+      currentIndex: initialIndex ?? 0,
+      elapsedSec: initialElapsedSec ?? 0,
+      answersStatus: initialAnswersStatus ?? {},
     }),
 
   setCurrentIndex: (index) => set({ currentIndex: index }),
@@ -60,6 +77,11 @@ export const useExamStore = create<ExamState & ExamActions>((set) => ({
   setAnswer: (index, choiceIds) =>
     set((state) => ({
       answers: { ...state.answers, [index]: choiceIds },
+    })),
+
+  setAnswerStatus: (index, isCorrect) =>
+    set((state) => ({
+      answersStatus: { ...state.answersStatus, [index]: isCorrect },
     })),
 
   incrementElapsed: () =>
@@ -87,12 +109,14 @@ export const useElapsedSec = () => useExamStore((s) => s.elapsedSec)
 export const useTimeLimit = () => useExamStore((s) => s.timeLimit)
 export const useIsCompleted = () => useExamStore((s) => s.isCompleted)
 export const useAnswers = () => useExamStore((s) => s.answers)
+export const useAnswersStatus = () => useExamStore((s) => s.answersStatus)
 export const useExamActions = () =>
   useExamStore(
     useShallow((s) => ({
       startSession: s.startSession,
       setCurrentIndex: s.setCurrentIndex,
       setAnswer: s.setAnswer,
+      setAnswerStatus: s.setAnswerStatus,
       incrementElapsed: s.incrementElapsed,
       recordQuestionTime: s.recordQuestionTime,
       complete: s.complete,

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -20,6 +20,8 @@ export const queryKeys = {
     results: (id: string) => ['sessions', id, 'results'] as const,
     previewFilter: (workbookId: string) =>
       ['sessions', 'preview-filter', workbookId] as const,
+    inProgress: (workbookId: string) =>
+      ['sessions', 'in-progress', workbookId] as const,
   },
   stats: {
     overview: (filters?: Record<string, string>) =>

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -94,6 +94,30 @@ export interface SessionQuestion {
   selectedChoiceIds: string[]
 }
 
+export interface InProgressSession {
+  id: string
+  mode: 'practice' | 'exam'
+  totalQuestions: number
+  answeredCount: number
+  firstUnansweredIndex: number
+  timeSpentSec: number
+  startedAt: string
+}
+
+export interface SessionDetail {
+  id: string
+  workbookId: string
+  mode: 'practice' | 'exam'
+  status: 'in_progress' | 'completed' | 'abandoned'
+  totalQuestions: number
+  answeredCount: number
+  firstUnansweredIndex: number
+  timeSpentSec: number
+  timeLimit: number | null
+  startedAt: string
+  answersStatus: Record<number, boolean>
+}
+
 export interface AnswerFeedback {
   isCorrect: boolean
   explanation: string | null


### PR DESCRIPTION
## Summary
PR#1 のマージで main のビルドが壊れたため修復する。`practice.tsx` が依存する型/ストア/クエリキーの変更が未コミットだったため、型エラーでデプロイ失敗 (run 24837953796)。

## Changes
- `packages/web/src/features/exam/stores/exam-store.ts`: `useAnswersStatus`, `setAnswerStatus`, `initialIndex` 等を追加
- `packages/web/src/types/index.ts`: `InProgressSession`, `SessionDetail` 型を追加
- `packages/web/src/lib/query-keys.ts`: `sessions.inProgress` を追加
- `packages/web/src/components/shared/mobile-question-nav.tsx`: `answersStatus` prop を追加
- `packages/web/src/app/routes/exam.tsx`: 関連更新

## Test plan
- [x] ローカルで `pnpm --filter @exam-app/web build` が成功
- [ ] CI のデプロイが成功すること
- [ ] 演習画面の再開・中止・回答送信が動作すること