### PR TITLE
fix: 中止後に同じ問題集を開始すると中止済みセッションが再開される不具合を修正

### DIFF
--- a/packages/web/src/app/routes/exam.tsx
+++ b/packages/web/src/app/routes/exam.tsx
@@ -144,6 +144,10 @@ export default function ExamPage() {
   const discardAndStartMutation = useMutation({
     mutationFn: async (existingSessionId: string) => {
       await api.post(`/sessions/${existingSessionId}/abort`, {})
+      queryClient.setQueryData(
+        queryKeys.sessions.inProgress(workbookId ?? ''),
+        { success: true, data: null },
+      )
       return api.post<CreateSessionResponse>('/sessions', {
         workbookId,
         mode: 'exam',
@@ -161,11 +165,8 @@ export default function ExamPage() {
     },
   })
 
-  const hasAutoResumedRef = useRef(false)
-
   useEffect(() => {
     setIsConfirmed(false)
-    hasAutoResumedRef.current = false
     reset()
     return () => {
       reset()
@@ -179,18 +180,6 @@ export default function ExamPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConfirmed])
-
-  useEffect(() => {
-    if (hasAutoResumedRef.current) return
-    if (inProgressQuery.isLoading) return
-    if (!inProgressSession) return
-    if (isConfirmed) return
-    hasAutoResumedRef.current = true
-    resumeSessionMutation.mutate(inProgressSession.id, {
-      onSuccess: () => setIsConfirmed(true),
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inProgressQuery.isLoading, inProgressSession, isConfirmed])
 
   useEffect(() => {
     if (!sessionId) return
@@ -244,9 +233,10 @@ export default function ExamPage() {
     }
     complete()
     reset()
-    await queryClient.invalidateQueries({
-      queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
-    })
+    queryClient.setQueryData(
+      queryKeys.sessions.inProgress(workbookId ?? ''),
+      { success: true, data: null },
+    )
     navigate(-1)
   }, [sessionId, workbookId, navigate, complete, reset, queryClient])
 

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -174,6 +174,10 @@ export default function PracticePage() {
   const discardAndStartMutation = useMutation({
     mutationFn: async (existingSessionId: string) => {
       await api.post(`/sessions/${existingSessionId}/abort`, {})
+      queryClient.setQueryData(
+        queryKeys.sessions.inProgress(workbookId ?? ''),
+        { success: true, data: null },
+      )
       return api.post<CreateSessionResponse>('/sessions', {
         workbookId,
         mode: 'practice',
@@ -194,11 +198,8 @@ export default function PracticePage() {
     },
   })
 
-  const hasAutoResumedRef = useRef(false)
-
   useEffect(() => {
     setIsConfirmed(false)
-    hasAutoResumedRef.current = false
     reset()
     return () => {
       reset()
@@ -212,18 +213,6 @@ export default function PracticePage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConfirmed])
-
-  useEffect(() => {
-    if (hasAutoResumedRef.current) return
-    if (inProgressQuery.isLoading) return
-    if (!inProgressSession) return
-    if (isConfirmed) return
-    hasAutoResumedRef.current = true
-    resumeSessionMutation.mutate(inProgressSession.id, {
-      onSuccess: () => setIsConfirmed(true),
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inProgressQuery.isLoading, inProgressSession, isConfirmed])
 
   useEffect(() => {
     if (!sessionId) return
@@ -391,9 +380,10 @@ export default function PracticePage() {
     }
     complete()
     reset()
-    await queryClient.invalidateQueries({
-      queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
-    })
+    queryClient.setQueryData(
+      queryKeys.sessions.inProgress(workbookId ?? ''),
+      { success: true, data: null },
+    )
     navigate(-1)
   }, [sessionId, workbookId, navigate, complete, reset, queryClient])
 


### PR DESCRIPTION
closes #3

## Summary

- `handleAbort` / `discardAndStartMutation` で `invalidateQueries` の代わりに `setQueryData` を使い、in-progress キャッシュを即座に `null` に上書き（stale なキャッシュが再利用されるのを防ぐ）
- auto-resume `useEffect` を削除し、UI の「前回の続きがあります（続きから再開 / 破棄して最初から）」ピッカーで必ずユーザーが選択するフローに統一
- 演習モード（`practice.tsx`）・実戦モード（`exam.tsx`）の両方に同じ修正を適用

## 原因と修正方針

1. `invalidateQueries` はキャッシュを stale としてマークするだけで削除はしない → 再アクセス時に React Query は古いキャッシュ値を即座に返してしまう
2. その結果 `inProgressQuery.isLoading` は false になり、auto-resume `useEffect` が中止済みセッションで発火 → 中止したはずのセッションの途中に戻されていた
3. そもそも auto-resume が UI ピッカーを完全にバイパスしており UX と矛盾していたため、ロジックごと削除

## Test plan

- [ ] 演習モードで数問回答 → 中止 → 同じ問題集を開始 → **新規セッションで最初から**始まることを確認
- [ ] 実戦モードで数問回答 → 中止 → 同じ問題集を開始 → 新規セッションで最初から始まることを確認
- [ ] 未中止で離脱した後に同じ問題集を開くと「前回の続きがあります」ピッカーが表示されることを確認
- [ ] ピッカーの「続きから再開」で前回の続きからスタートすることを確認
- [ ] ピッカーの「破棄して最初から」で新規セッションとして最初からスタートすることを確認