### PR TITLE
fix: 「破棄して最初から」で自信度フィルタ選択画面を経由するように修正

### DIFF
--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -171,30 +171,13 @@ export default function PracticePage() {
     },
   })
 
-  const discardAndStartMutation = useMutation({
+  const discardMutation = useMutation({
     mutationFn: async (existingSessionId: string) => {
       await api.post(`/sessions/${existingSessionId}/abort`, {})
       queryClient.setQueryData(
         queryKeys.sessions.inProgress(workbookId ?? ''),
         { success: true, data: null },
       )
-      return api.post<CreateSessionResponse>('/sessions', {
-        workbookId,
-        mode: 'practice',
-        ...(filterConfidenceLevels.length > 0
-          ? { filters: { confidenceLevels: filterConfidenceLevels } }
-          : {}),
-      })
-    },
-    onSuccess: (response) => {
-      if (response.data) {
-        startSession({
-          sessionId: response.data.id,
-          mode: 'practice',
-          totalQuestions: response.data.totalQuestions,
-          timeLimit: response.data.timeLimit,
-        })
-      }
     },
   })
 
@@ -440,7 +423,7 @@ export default function PracticePage() {
 
   if (!isConfirmed) {
     const isResumePending =
-      resumeSessionMutation.isPending || discardAndStartMutation.isPending
+      resumeSessionMutation.isPending || discardMutation.isPending
 
     if (inProgressQuery.isLoading || isResumePending) {
       return (
@@ -510,14 +493,12 @@ export default function PracticePage() {
                 </button>
                 <button
                   onClick={() => {
-                    discardAndStartMutation.mutate(inProgressSession.id, {
-                      onSuccess: () => setIsConfirmed(true),
-                    })
+                    discardMutation.mutate(inProgressSession.id)
                   }}
                   disabled={isResumePending}
                   className="min-h-[44px] rounded-lg px-4 py-2 text-sm text-muted-foreground hover:bg-muted disabled:opacity-50"
                 >
-                  破棄して最初から
+                  {discardMutation.isPending ? '破棄中…' : '破棄して最初から'}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
closes #5

## Summary

- `discardAndStartMutation` を `discardMutation` に分割し、「中止のみ」を行うように変更
- 中止後は `inProgressSession` が null になり、UI が自動的に通常の開始フロー（フィルタ選択 → 開始ボタン）に合流
- 破棄処理中は「破棄中…」のラベルを表示

## 原因

`discardAndStartMutation` が「中止 + 新規セッション作成」を一括で行っていたため、ユーザーが自信度フィルタを選択する機会がなかった（空の filter で常に全問対象になる）。

## Test plan

- [ ] 未中止の in-progress セッションがある状態で同じ問題集を開く → ピッカーが表示される
- [ ] 「破棄して最初から」を押す → フィルタ選択画面 + 開始ボタンが表示される
- [ ] フィルタを選択して「開始」→ フィルタが適用されたセッションが始まる
- [ ] フィルタを選択せずに「開始」→ 全問対象のセッションが始まる
- [ ] 「続きから再開」は従来通りに動く