### PR TITLE
fix(ci): Pagesデプロイのcommit messageをSHA指定にしてUTF-8エラーを回避

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy Pages
-        run: pnpm --filter @exam-app/server exec wrangler pages deploy ../web/dist --project-name=exam-app --branch=main
+        run: |
+          pnpm --filter @exam-app/server exec wrangler pages deploy ../web/dist \
+            --project-name=exam-app \
+            --branch=main \
+            --commit-hash="${{ github.sha }}" \
+            --commit-message="Deploy ${{ github.sha }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- `wrangler pages deploy` に `--commit-hash` と `--commit-message` を明示指定し、git からの自動検出を無効化
- 日本語コミットメッセージがあっても Pages のデプロイが失敗しないようにする

## 背景

main への push 時に走る Deploy ワークフローで、Workers のデプロイは成功するが Pages のデプロイだけが以下のエラーで失敗していた。

\`\`\`
✘ [ERROR] A request to the Cloudflare API (/accounts/***/pages/projects/exam-app/deployments) failed.
  Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]
\`\`\`

`wrangler pages deploy` はオプション未指定時に git のコミットメッセージを自動検出して Cloudflare API に送信するが、日本語メッセージを含む場合に壊れたバイト列を送ってしまう既知の問題がある（wrangler 側の内部処理）。

## 修正方針

コミットメッセージの自動検出をバイパスし、`github.sha` を使った安定した値を渡す。

\`\`\`yaml
--commit-hash="${{ github.sha }}" \\
--commit-message="Deploy ${{ github.sha }}"
\`\`\`

## Test plan

- [ ] merge 後、main への push で Deploy ワークフローが最後まで通ることを確認
- [ ] Cloudflare Pages のダッシュボード上で新しいデプロイが表示され、コミットハッシュが紐づいていることを確認