### PR TITLE
fix(server): 同一workbookの孤児 in_progress セッションをまとめて破棄

### DIFF
--- a/packages/server/src/api/routes/sessions.ts
+++ b/packages/server/src/api/routes/sessions.ts
@@ -99,6 +99,17 @@ app.post('/', async (c) => {
   const timestamp = now()
   const sessionId = generateUlid()
 
+  await db
+    .update(examSessions)
+    .set({ status: 'abandoned', completedAt: timestamp })
+    .where(
+      and(
+        eq(examSessions.userId, userId),
+        eq(examSessions.workbookId, body.workbookId),
+        eq(examSessions.status, 'in_progress'),
+      ),
+    )
+
   await db.insert(examSessions).values({
     id: sessionId,
     userId,
@@ -585,15 +596,28 @@ app.post('/:id/abort', async (c) => {
       ? Math.max(session.timeSpentSec ?? 0, body.timeSpentSec)
       : (session.timeSpentSec ?? 0)
 
+  const timestamp = now()
+
   await db
     .update(examSessions)
     .set({
       status: 'abandoned',
       totalQuestions: answered.length,
-      completedAt: now(),
+      completedAt: timestamp,
       timeSpentSec: nextElapsed,
     })
     .where(eq(examSessions.id, sessionId))
+
+  await db
+    .update(examSessions)
+    .set({ status: 'abandoned', completedAt: timestamp })
+    .where(
+      and(
+        eq(examSessions.userId, userId),
+        eq(examSessions.workbookId, session.workbookId),
+        eq(examSessions.status, 'in_progress'),
+      ),
+    )
 
   return c.json({ success: true, data: { id: sessionId } })
 })


### PR DESCRIPTION
closes #8

## Summary

- `POST /sessions`: 新規作成の直前に、同じ user + workbook の `in_progress` セッションを全て `abandoned` に更新
- `POST /sessions/:id/abort`: 指定セッションの abort 後、同じ user + workbook に残っている他の `in_progress` セッションもまとめて `abandoned` に更新
- これで「user + workbook につき `in_progress` は高々1つ」の不変条件が各操作後に成立する

## 背景

過去のテストや旧バグで生じた複数の孤児 `in_progress` セッションが DB に残っていると、`/in-progress/:workbookId` は最新1件しか返さないため、ユーザーが最新を中止/完了しても次の孤児が順々に「前回の続きがあります」picker に現れ続けてしまう。

## マイグレーションは不要

残存する孤児は、修正後にユーザーが **一度でも「破棄して最初から」または「開始」（新規作成）を実行した時点** で全て abandoned される。ユーザー毎に最大 1 回だけ picker が余分に出るかもしれないが、その後は恒久的に解消する。

## Test plan

- [ ] 同一 user + workbook で複数の `in_progress` レコードを手動で作成しておく
- [ ] 問題集を開く → picker は1件だけ表示されることを確認
- [ ] 「破棄して最初から」→「開始」→ 完了 → 再度開く → picker が出ないことを確認
- [ ] 既存の「続きから再開」フローが壊れていないことを確認
- [ ] 「中止」ボタンだけ押した場合も、残っていた孤児が掃除されることを確認