### PR TITLE
fix(web): APIリクエストにタイムアウトを設定して無限ローディングを防ぐ

### DIFF
--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -2,10 +2,29 @@ const API_BASE = import.meta.env.VITE_API_URL
   ? `${import.meta.env.VITE_API_URL}/api/v1`
   : '/api/v1'
 
+const REQUEST_TIMEOUT_MS = 15_000
+const TOKEN_TIMEOUT_MS = 5_000
+
 type RequestOptions = {
   method?: string
   body?: unknown
   params?: Record<string, string>
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
 }
 
 async function request<T>(
@@ -25,16 +44,33 @@ async function request<T>(
     'Content-Type': 'application/json',
   }
 
-  const token = await getAuthToken()
+  const token = await withTimeout(
+    getAuthToken(),
+    TOKEN_TIMEOUT_MS,
+    '認証トークンの取得がタイムアウトしました',
+  )
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
   }
 
-  const response = await fetch(url.toString(), {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  })
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(url.toString(), {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    })
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('リクエストがタイムアウトしました')
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Request failed' }))


### PR DESCRIPTION
closes #10

## Summary

- `fetch` に 15 秒の `AbortController` ベースのタイムアウトを追加
- `getAuthToken()` に 5 秒の `withTimeout` ラッパーを追加
- タイムアウト時は日本語のエラーメッセージで reject

## 背景

モバイル端末から「演習」「実戦」を押した後、ローディングスピナーが永続する報告があった。api-client のどの段階でも fetch / Clerk の `getToken()` にタイムアウトが無く、ネットワーク事情（iOS Safari ITP、CORS preflight 遅延など）で止まるとユーザーは永遠に待たされる。

## 修正のねらい

- 無限ローディングを **確実に可視なエラー状態へ遷移** させる（React Query の retry + isError で表示される）
- 根本原因（Clerk ハング / fetch ハング / CORS / など）の特定は別途行うが、先にユーザー被害を止める
- 他の API 呼び出しにも同じ利点が波及する（general defensive measure）

## Test plan

- [ ] 通常の API 通信で動作に変化がないことを確認（演習開始、回答、完了が従来通り動く）
- [ ] ネットワークを遮断した状態でページを開き、15 秒以内にエラー画面に遷移することを確認
- [ ] 複数回試行しても前回のタイムアウトが次の試行に残らないことを確認（AbortController が使い捨て）

## 補足

根本原因は後続タスクで特定する。本 PR は UX 安全ネット。