### PR TITLE
perf: クエリ・キャッシュ・インデックスの総合最適化

### DIFF
--- a/packages/server/migrations/0004_curvy_miss_america.sql
+++ b/packages/server/migrations/0004_curvy_miss_america.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_question_sets_user_subject` ON `question_sets` (`user_id`,`category_id`);

--- a/packages/server/migrations/meta/0004_snapshot.json
+++ b/packages/server/migrations/meta/0004_snapshot.json
@@ -1,0 +1,954 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5bdd725b-e2cc-40ba-8ed0-5f75d1db4096",
+  "prevId": "74bf2563-6b28-4e91-9336-23e6163927ff",
+  "tables": {
+    "choices": {
+      "name": "choices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_choices_question_id": {
+          "name": "idx_choices_question_id",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "choices_question_id_questions_id_fk": {
+          "name": "choices_question_id_questions_id_fk",
+          "tableFrom": "choices",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_sessions": {
+      "name": "exam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_set_id": {
+          "name": "question_set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_order": {
+          "name": "question_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_questions": {
+          "name": "total_questions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correct_count": {
+          "name": "correct_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score_percent": {
+          "name": "score_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_spent_sec": {
+          "name": "time_spent_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_exam_sessions_user_id": {
+          "name": "idx_exam_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_exam_sessions_question_set_id": {
+          "name": "idx_exam_sessions_question_set_id",
+          "columns": [
+            "question_set_id"
+          ],
+          "isUnique": false
+        },
+        "idx_exam_sessions_status": {
+          "name": "idx_exam_sessions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_exam_sessions_user_status": {
+          "name": "idx_exam_sessions_user_status",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exam_sessions_question_set_id_question_sets_id_fk": {
+          "name": "exam_sessions_question_set_id_question_sets_id_fk",
+          "tableFrom": "exam_sessions",
+          "tableTo": "question_sets",
+          "columnsFrom": [
+            "question_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "question_confidence": {
+      "name": "question_confidence",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_question_confidence_user_question": {
+          "name": "idx_question_confidence_user_question",
+          "columns": [
+            "user_id",
+            "question_id"
+          ],
+          "isUnique": true
+        },
+        "idx_question_confidence_user_id": {
+          "name": "idx_question_confidence_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "question_confidence_question_id_questions_id_fk": {
+          "name": "question_confidence_question_id_questions_id_fk",
+          "tableFrom": "question_confidence",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "question_tags": {
+      "name": "question_tags",
+      "columns": {
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_tags_question_id_questions_id_fk": {
+          "name": "question_tags_question_id_questions_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_tags_tag_id_tags_id_fk": {
+          "name": "question_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_tags_question_id_tag_id_pk": {
+          "columns": [
+            "question_id",
+            "tag_id"
+          ],
+          "name": "question_tags_question_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_set_id": {
+          "name": "question_set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_multi_answer": {
+          "name": "is_multi_answer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_questions_question_set_id": {
+          "name": "idx_questions_question_set_id",
+          "columns": [
+            "question_set_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "questions_question_set_id_question_sets_id_fk": {
+          "name": "questions_question_set_id_question_sets_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "question_sets",
+          "columnsFrom": [
+            "question_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_answer_choices": {
+      "name": "session_answer_choices",
+      "columns": {
+        "session_answer_id": {
+          "name": "session_answer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice_id": {
+          "name": "choice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_answer_choices_session_answer_id_session_answers_id_fk": {
+          "name": "session_answer_choices_session_answer_id_session_answers_id_fk",
+          "tableFrom": "session_answer_choices",
+          "tableTo": "session_answers",
+          "columnsFrom": [
+            "session_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_answer_choices_session_answer_id_choice_id_pk": {
+          "columns": [
+            "session_answer_id",
+            "choice_id"
+          ],
+          "name": "session_answer_choices_session_answer_id_choice_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_answers": {
+      "name": "session_answers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice_order": {
+          "name": "choice_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "question_version": {
+          "name": "question_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_snapshot": {
+          "name": "question_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_spent_sec": {
+          "name": "time_spent_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_answers_session_id": {
+          "name": "idx_session_answers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_session_answers_question_id": {
+          "name": "idx_session_answers_question_id",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        },
+        "idx_session_answers_session_question": {
+          "name": "idx_session_answers_session_question",
+          "columns": [
+            "session_id",
+            "question_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_answers_session_id_exam_sessions_id_fk": {
+          "name": "session_answers_session_id_exam_sessions_id_fk",
+          "tableFrom": "session_answers",
+          "tableTo": "exam_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_answers_question_id_questions_id_fk": {
+          "name": "session_answers_question_id_questions_id_fk",
+          "tableFrom": "session_answers",
+          "tableTo": "questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pass_score": {
+          "name": "pass_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_categories_user_id": {
+          "name": "idx_categories_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_user_name": {
+          "name": "idx_tags_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_tags_user_id": {
+          "name": "idx_tags_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "question_set_tags": {
+      "name": "question_set_tags",
+      "columns": {
+        "question_set_id": {
+          "name": "question_set_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_set_tags_question_set_id_question_sets_id_fk": {
+          "name": "question_set_tags_question_set_id_question_sets_id_fk",
+          "tableFrom": "question_set_tags",
+          "tableTo": "question_sets",
+          "columnsFrom": [
+            "question_set_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "question_set_tags_tag_id_tags_id_fk": {
+          "name": "question_set_tags_tag_id_tags_id_fk",
+          "tableFrom": "question_set_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_set_tags_question_set_id_tag_id_pk": {
+          "columns": [
+            "question_set_id",
+            "tag_id"
+          ],
+          "name": "question_set_tags_question_set_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "question_sets": {
+      "name": "question_sets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_limit": {
+          "name": "time_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_question_sets_user_id": {
+          "name": "idx_question_sets_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_question_sets_user_subject": {
+          "name": "idx_question_sets_user_subject",
+          "columns": [
+            "user_id",
+            "category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "question_sets_category_id_categories_id_fk": {
+          "name": "question_sets_category_id_categories_id_fk",
+          "tableFrom": "question_sets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/migrations/meta/_journal.json
+++ b/packages/server/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775131150705,
       "tag": "0003_living_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777035771474,
+      "tag": "0004_curvy_miss_america",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/api/routes/questions.ts
+++ b/packages/server/src/api/routes/questions.ts
@@ -170,15 +170,18 @@ app.patch('/:setId/questions/reorder', async (c) => {
   await getWorkbookForUser(db, setId, userId)
   const body = reorderQuestionsSchema.parse(await c.req.json())
 
+  if (body.orders.length === 0) {
+    return c.json({ success: true })
+  }
+
   const timestamp = now()
-  await Promise.all(
-    body.orders.map(({ id, sortOrder }) =>
-      db
-        .update(questions)
-        .set({ sortOrder, updatedAt: timestamp })
-        .where(eq(questions.id, id)),
-    ),
+  const statements = body.orders.map(({ id, sortOrder }) =>
+    db
+      .update(questions)
+      .set({ sortOrder, updatedAt: timestamp })
+      .where(and(eq(questions.id, id), eq(questions.workbookId, setId))),
   )
+  await db.batch(statements as unknown as Parameters<typeof db.batch>[0])
 
   return c.json({ success: true })
 })

--- a/packages/server/src/api/routes/stats.ts
+++ b/packages/server/src/api/routes/stats.ts
@@ -153,7 +153,7 @@ app.get('/history', async (c) => {
 
   const conditions = buildSessionFilters(userId, { subjectId, workbookId })
 
-  const sessions = await db
+  const rows = await db
     .select({
       id: examSessions.id,
       mode: examSessions.mode,
@@ -166,6 +166,7 @@ app.get('/history', async (c) => {
       timeSpentSec: examSessions.timeSpentSec,
       workbookTitle: workbooks.title,
       subjectName: subjects.name,
+      total: sql<number>`count(*) over()`,
     })
     .from(examSessions)
     .innerJoin(workbooks, eq(examSessions.workbookId, workbooks.id))
@@ -175,13 +176,8 @@ app.get('/history', async (c) => {
     .limit(limit)
     .offset(offset)
 
-  const countResult = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(examSessions)
-    .innerJoin(workbooks, eq(examSessions.workbookId, workbooks.id))
-    .where(and(...conditions))
-
-  const total = countResult[0]?.count ?? 0
+  const total = rows[0]?.total ?? 0
+  const sessions = rows.map(({ total: _total, ...rest }) => rest)
 
   return c.json({
     success: true,
@@ -252,25 +248,36 @@ app.get('/workbook-scores', async (c) => {
 
   const conditions = buildSessionFilters(userId, { subjectId, workbookId })
 
-  let query = db
+  let inner = db
     .select({
       workbookId: examSessions.workbookId,
       scorePercent: examSessions.scorePercent,
       completedAt: examSessions.completedAt,
+      rn: sql<number>`row_number() over (partition by ${examSessions.workbookId} order by ${examSessions.completedAt} desc)`.as(
+        'rn',
+      ),
     })
     .from(examSessions)
     .$dynamic()
 
   if (subjectId) {
-    query = query.innerJoin(
+    inner = inner.innerJoin(
       workbooks,
       eq(examSessions.workbookId, workbooks.id),
     )
   }
 
-  const sessions = await query
-    .where(and(...conditions))
-    .orderBy(desc(examSessions.completedAt))
+  const ranked = inner.where(and(...conditions)).as('ranked')
+
+  const sessions = await db
+    .select({
+      workbookId: ranked.workbookId,
+      scorePercent: ranked.scorePercent,
+      completedAt: ranked.completedAt,
+    })
+    .from(ranked)
+    .where(sql`${ranked.rn} <= ${limit}`)
+    .orderBy(ranked.workbookId, desc(ranked.completedAt))
 
   const grouped: Record<
     string,
@@ -281,9 +288,7 @@ app.get('/workbook-scores', async (c) => {
     if (!grouped[s.workbookId]) {
       grouped[s.workbookId] = { scores: [], lastPlayedAt: s.completedAt }
     }
-    if (grouped[s.workbookId].scores.length < limit) {
-      grouped[s.workbookId].scores.push(s.scorePercent ?? 0)
-    }
+    grouped[s.workbookId].scores.push(s.scorePercent ?? 0)
   }
 
   const data = Object.entries(grouped).map(([wbId, v]) => ({

--- a/packages/server/src/db/schema/workbooks.ts
+++ b/packages/server/src/db/schema/workbooks.ts
@@ -23,7 +23,10 @@ export const workbooks = sqliteTable(
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
   },
-  (table) => [index('idx_question_sets_user_id').on(table.userId)],
+  (table) => [
+    index('idx_question_sets_user_id').on(table.userId),
+    index('idx_question_sets_user_subject').on(table.userId, table.subjectId),
+  ],
 )
 
 export const workbookTags = sqliteTable(

--- a/packages/web/src/app/routes/admin-subjects.tsx
+++ b/packages/web/src/app/routes/admin-subjects.tsx
@@ -347,13 +347,32 @@ export default function AdminSubjectsPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete<ApiResponse<null>>(`/subjects/${id}`),
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.subjects.all })
+      const previous = queryClient.getQueryData<ApiResponse<Subject[]>>(
+        queryKeys.subjects.all,
+      )
+      queryClient.setQueryData<ApiResponse<Subject[]>>(
+        queryKeys.subjects.all,
+        (old) =>
+          old?.data
+            ? { ...old, data: old.data.filter((s) => s.id !== id) }
+            : old,
+      )
+      return { previous }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.subjects.all })
       queryClient.invalidateQueries({ queryKey: queryKeys.workbooks.all })
       setDeletingId(null)
       setMutationError(null)
     },
-    onError: (error: Error) => setMutationError(error.message),
+    onError: (error: Error, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKeys.subjects.all, context.previous)
+      }
+      setMutationError(error.message)
+    },
   })
 
   if (subjectsQuery.isLoading) return <LoadingSkeleton />

--- a/packages/web/src/app/routes/admin-subjects.tsx
+++ b/packages/web/src/app/routes/admin-subjects.tsx
@@ -315,6 +315,7 @@ export default function AdminSubjectsPage() {
   const subjectsQuery = useQuery({
     queryKey: queryKeys.subjects.all,
     queryFn: () => api.get<ApiResponse<Subject[]>>('/subjects'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const setsQuery = useQuery({

--- a/packages/web/src/app/routes/admin-tags.tsx
+++ b/packages/web/src/app/routes/admin-tags.tsx
@@ -274,6 +274,7 @@ export default function AdminTagsPage() {
   const tagsQuery = useQuery({
     queryKey: queryKeys.tags.all,
     queryFn: () => api.get<ApiResponse<Tag[]>>('/tags'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const createMutation = useMutation({

--- a/packages/web/src/app/routes/admin-tags.tsx
+++ b/packages/web/src/app/routes/admin-tags.tsx
@@ -301,12 +301,31 @@ export default function AdminTagsPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete<ApiResponse<null>>(`/tags/${id}`),
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.tags.all })
+      const previous = queryClient.getQueryData<ApiResponse<Tag[]>>(
+        queryKeys.tags.all,
+      )
+      queryClient.setQueryData<ApiResponse<Tag[]>>(
+        queryKeys.tags.all,
+        (old) =>
+          old?.data
+            ? { ...old, data: old.data.filter((t) => t.id !== id) }
+            : old,
+      )
+      return { previous }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.tags.all })
       setDeletingId(null)
       setMutationError(null)
     },
-    onError: (error: Error) => setMutationError(error.message),
+    onError: (error: Error, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKeys.tags.all, context.previous)
+      }
+      setMutationError(error.message)
+    },
   })
 
   if (tagsQuery.isLoading) return <LoadingSkeleton />

--- a/packages/web/src/app/routes/admin-workbook-edit.tsx
+++ b/packages/web/src/app/routes/admin-workbook-edit.tsx
@@ -289,11 +289,13 @@ export default function AdminWorkbookEditPage() {
   const subjectsQuery = useQuery({
     queryKey: queryKeys.subjects.all,
     queryFn: () => api.get<ApiResponse<Subject[]>>('/subjects'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const tagsQuery = useQuery({
     queryKey: queryKeys.tags.all,
     queryFn: () => api.get<ApiResponse<Tag[]>>('/tags'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const questionIds = useMemo(

--- a/packages/web/src/app/routes/admin-workbooks.tsx
+++ b/packages/web/src/app/routes/admin-workbooks.tsx
@@ -73,6 +73,7 @@ export default function AdminWorkbooksPage() {
   const subjectsQuery = useQuery({
     queryKey: queryKeys.subjects.all,
     queryFn: () => api.get<ApiResponse<Subject[]>>('/subjects'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const deleteMutation = useMutation({

--- a/packages/web/src/app/routes/admin-workbooks.tsx
+++ b/packages/web/src/app/routes/admin-workbooks.tsx
@@ -79,12 +79,29 @@ export default function AdminWorkbooksPage() {
   const deleteMutation = useMutation({
     mutationFn: (id: string) =>
       api.delete<ApiResponse<null>>(`/workbooks/${id}`),
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.workbooks.all })
+      const previous = queryClient.getQueryData<ApiResponse<Workbook[]>>(
+        queryKeys.workbooks.all,
+      )
+      queryClient.setQueryData<ApiResponse<Workbook[]>>(
+        queryKeys.workbooks.all,
+        (old) =>
+          old?.data
+            ? { ...old, data: old.data.filter((w) => w.id !== id) }
+            : old,
+      )
+      return { previous }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.workbooks.all })
       setDeletingId(null)
       setMutationError(null)
     },
-    onError: (error: Error) => {
+    onError: (error: Error, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKeys.workbooks.all, context.previous)
+      }
       setMutationError(error.message)
     },
   })

--- a/packages/web/src/app/routes/dashboard.tsx
+++ b/packages/web/src/app/routes/dashboard.tsx
@@ -611,6 +611,7 @@ export default function Dashboard() {
   const subjectsQuery = useQuery({
     queryKey: queryKeys.subjects.all,
     queryFn: () => api.get<ApiResponse<Subject[]>>('/subjects'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const statsQuery = useQuery({

--- a/packages/web/src/app/routes/exam.tsx
+++ b/packages/web/src/app/routes/exam.tsx
@@ -207,7 +207,11 @@ export default function ExamPage() {
       })
       complete()
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['stats'] }),
+        queryClient.invalidateQueries({ queryKey: ['stats', 'history'] }),
+        queryClient.invalidateQueries({ queryKey: ['stats', 'overview'] }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.stats.workbookScores,
+        }),
         queryClient.invalidateQueries({
           queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
         }),

--- a/packages/web/src/app/routes/exam.tsx
+++ b/packages/web/src/app/routes/exam.tsx
@@ -100,7 +100,7 @@ export default function ExamPage() {
         `/sessions/in-progress/${workbookId}`,
       ),
     enabled: !!workbookId && !isConfirmed,
-    staleTime: 0,
+    staleTime: 1000 * 30,
     retry: false,
   })
 
@@ -265,6 +265,7 @@ export default function ExamPage() {
         `/sessions/${sessionId}/questions/${currentIndex}`,
       ),
     enabled: !!sessionId,
+    staleTime: Infinity,
   })
 
   const question = questionQuery.data?.data ?? null

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -337,7 +337,11 @@ export default function PracticePage() {
       })
       complete()
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['stats'] }),
+        queryClient.invalidateQueries({ queryKey: ['stats', 'history'] }),
+        queryClient.invalidateQueries({ queryKey: ['stats', 'overview'] }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.stats.workbookScores,
+        }),
         queryClient.invalidateQueries({
           queryKey: queryKeys.sessions.inProgress(workbookId ?? ''),
         }),

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -91,7 +91,7 @@ export default function PracticePage() {
         workbookId,
       }),
     enabled: !!workbookId && !isConfirmed,
-    staleTime: 0,
+    staleTime: 1000 * 60,
   })
 
   const filterPreview = previewQuery.data?.data
@@ -126,7 +126,7 @@ export default function PracticePage() {
         `/sessions/in-progress/${workbookId}`,
       ),
     enabled: !!workbookId && !isConfirmed,
-    staleTime: 0,
+    staleTime: 1000 * 30,
     retry: false,
   })
 
@@ -221,6 +221,7 @@ export default function PracticePage() {
         `/sessions/${sessionId}/questions/${currentIndex}`,
       ),
     enabled: !!sessionId,
+    staleTime: Infinity,
   })
 
   const question = questionQuery.data?.data ?? null

--- a/packages/web/src/app/routes/stats.tsx
+++ b/packages/web/src/app/routes/stats.tsx
@@ -214,6 +214,7 @@ export default function HistoryPage() {
   const subjectsQuery = useQuery({
     queryKey: queryKeys.subjects.all,
     queryFn: () => api.get<ApiResponse<Subject[]>>('/subjects'),
+    staleTime: 1000 * 60 * 30,
   })
 
   const allWorkbooksQuery = useQuery({

--- a/packages/web/src/components/shared/confidence-selector.tsx
+++ b/packages/web/src/components/shared/confidence-selector.tsx
@@ -29,8 +29,31 @@ export function ConfidenceSelector({
       ),
     onMutate: async (newLevel) => {
       onLevelChange?.(newLevel)
+
+      await queryClient.cancelQueries({ queryKey: ['confidence', 'batch'] })
+      const previousBatches = queryClient.getQueriesData<
+        ApiResponse<Record<string, number>>
+      >({ queryKey: ['confidence', 'batch'] })
+      queryClient.setQueriesData<ApiResponse<Record<string, number>>>(
+        { queryKey: ['confidence', 'batch'] },
+        (old) => {
+          if (!old?.data) return old
+          return {
+            ...old,
+            data: { ...old.data, [questionId]: newLevel },
+          }
+        },
+      )
+      return { previousBatches }
     },
-    onSuccess: () => {
+    onError: (_err, _newLevel, context) => {
+      if (context?.previousBatches) {
+        for (const [key, data] of context.previousBatches) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.confidence.byQuestion(questionId),
       })

--- a/packages/web/src/lib/query-client.ts
+++ b/packages/web/src/lib/query-client.ts
@@ -4,7 +4,9 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 30,
       retry: 1,
+      refetchOnWindowFocus: false,
     },
   },
 })

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -1,3 +1,17 @@
+type FilterInput = Record<string, string | undefined> | undefined
+
+function normalizeFilters(filters: FilterInput): Record<string, string> {
+  if (!filters) return {}
+  const entries: [string, string][] = []
+  for (const key of Object.keys(filters).sort()) {
+    const value = filters[key]
+    if (value !== undefined && value !== '') {
+      entries.push([key, value])
+    }
+  }
+  return Object.fromEntries(entries)
+}
+
 export const queryKeys = {
   subjects: {
     all: ['subjects'] as const,
@@ -9,8 +23,8 @@ export const queryKeys = {
   },
   workbooks: {
     all: ['workbooks'] as const,
-    list: (filters: Record<string, string>) =>
-      ['workbooks', filters] as const,
+    list: (filters?: FilterInput) =>
+      ['workbooks', 'list', normalizeFilters(filters)] as const,
     detail: (id: string) => ['workbooks', id] as const,
   },
   sessions: {
@@ -24,22 +38,22 @@ export const queryKeys = {
       ['sessions', 'in-progress', workbookId] as const,
   },
   stats: {
-    overview: (filters?: Record<string, string>) =>
-      ['stats', 'overview', filters ?? {}] as const,
-    subjects: (filters?: Record<string, string>) =>
-      ['stats', 'subjects', filters ?? {}] as const,
-    tags: (filters?: Record<string, string>) =>
-      ['stats', 'tags', filters ?? {}] as const,
-    history: (page: number, filters?: Record<string, string>) =>
-      ['stats', 'history', page, filters ?? {}] as const,
-    weakAreas: (filters?: Record<string, string>) =>
-      ['stats', 'weakAreas', filters ?? {}] as const,
+    overview: (filters?: FilterInput) =>
+      ['stats', 'overview', normalizeFilters(filters)] as const,
+    subjects: (filters?: FilterInput) =>
+      ['stats', 'subjects', normalizeFilters(filters)] as const,
+    tags: (filters?: FilterInput) =>
+      ['stats', 'tags', normalizeFilters(filters)] as const,
+    history: (page: number, filters?: FilterInput) =>
+      ['stats', 'history', page, normalizeFilters(filters)] as const,
+    weakAreas: (filters?: FilterInput) =>
+      ['stats', 'weakAreas', normalizeFilters(filters)] as const,
     workbookScores: ['stats', 'workbookScores'] as const,
   },
   confidence: {
     byQuestion: (questionId: string) =>
       ['confidence', questionId] as const,
     batch: (questionIds: string[]) =>
-      ['confidence', 'batch', questionIds] as const,
+      ['confidence', 'batch', [...questionIds].sort()] as const,
   },
 } as const


### PR DESCRIPTION
Closes #12

## Summary

- サーバ: stats系の重複クエリ撤廃・SQL集計化、問題並べ替えの batch 化
- キャッシュ: セッション完了時の invalidate 範囲を絞り込み、QueryClient の refetchOnWindowFocus をデフォルト無効化、クエリキー正規化、staleTime 個別調整
- インデックス: question_sets(user_id, category_id) 複合インデックス追加
- UX: confidence-selector / admin 削除の楽観更新

## Changes by Phase

### Phase 1 / P0 (`a6fce15`)
- `/stats/history` の count を `COUNT(*) OVER()` で1クエリに統合
- `/stats/workbook-scores` を ROW_NUMBER サブクエリで workbook 毎 limit 件に絞って取得
- 問題並べ替えを `db.batch()` で1往復に
- セッション完了時の invalidate を `history / overview / workbookScores` に絞り込み
- QueryClient デフォルト: `refetchOnWindowFocus: false`, `gcTime: 30分`
- queryKey ファクトリの filter / 配列を正規化（sort + 空値除去）

### Phase 2 / P1 (`82a8a73`)
- subjects / tags の useQuery に `staleTime: 30分`
- practice / exam の inProgress を `staleTime: 30秒`、preview-filter を `60秒`、session.question を `Infinity`
- confidence-selector に楽観更新: `confidence.batch` キャッシュを即時反映、失敗時 rollback

### Phase 3 / P2 (`a6ac22b`)
- `question_sets` に `(user_id, category_id)` 複合インデックス追加（migration 0004）
- admin subjects / tags / workbooks の削除 mutation を楽観更新化

## Non-goals（見送り項目）

監査で提案されたが実コード前提と合わず見送ったもの：

- useQueries 並列化 → 依存関係なしの useQuery は既に並列発火
- /workbooks/summary 新設 → 既に questionCount のみの軽量実装
- stats Cache-Control ヘッダ → invalidate と競合するリスク
- fetchQuestionsWithDetails 列選択 → 呼び出し元が全て詳細用途
- weak-areas の index 戦略 → 実データ量の EXPLAIN を経て判断

詳細は Issue #12 参照。

## Test plan

- [ ] `pnpm --filter server test` が通る
- [ ] `pnpm --filter web tsc --noEmit` が通る
- [ ] `pnpm --filter server db:migrate:local` で migration 0004 が適用される
- [ ] ダッシュボード初期表示で stats / workbook list / scores が取得できる
- [ ] 問題集履歴のページネーションで total 件数が正しく返る（`/stats/history`）
- [ ] 演習 / 実戦セッション完了後、ダッシュボードに新しいスコアが反映される
- [ ] admin 画面で subject / tag / workbook を削除すると即時リストから消え、失敗時にリストに戻る
- [ ] confidence-selector でレベル変更すると即時反映され、ネットワーク失敗時に元に戻る
- [ ] 問題並べ替え (reorder) が admin-workbook-edit で動作する
- [ ] 試験中にタブ切替しても refetch が発生しないこと（DevTools Network で確認）