### PR TITLE
feat(web): モバイルヘッダーを Contextual Header + ストリーク型に刷新

### DIFF
--- a/packages/web/src/app/routes/admin-import-export.tsx
+++ b/packages/web/src/app/routes/admin-import-export.tsx
@@ -4,6 +4,7 @@ import { api } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 import { ErrorMessage } from '@/components/shared/error-message'
 import type { ApiResponse, Workbook } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 interface ImportPreview {
   title: string
@@ -281,6 +282,8 @@ function ImportSection() {
 }
 
 export default function AdminImportExportPage() {
+  useMobileHeader({ variant: 'compact', title: 'インポート/エクスポート' })
+
   const setsQuery = useQuery({
     queryKey: queryKeys.workbooks.all,
     queryFn: () =>

--- a/packages/web/src/app/routes/admin-subjects.tsx
+++ b/packages/web/src/app/routes/admin-subjects.tsx
@@ -5,6 +5,7 @@ import { api } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 import { ErrorMessage } from '@/components/shared/error-message'
 import type { ApiResponse, Subject, Workbook } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 /* ─── Form types ─── */
 
@@ -306,6 +307,8 @@ function LoadingSkeleton() {
 /* ─── Main Page ─── */
 
 export default function AdminSubjectsPage() {
+  useMobileHeader({ variant: 'compact', title: '科目' })
+
   const queryClient = useQueryClient()
   const [showCreateForm, setShowCreateForm] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)

--- a/packages/web/src/app/routes/admin-tags.tsx
+++ b/packages/web/src/app/routes/admin-tags.tsx
@@ -4,6 +4,7 @@ import { api } from '@/lib/api-client'
 import { queryKeys } from '@/lib/query-keys'
 import { ErrorMessage } from '@/components/shared/error-message'
 import type { ApiResponse, Tag } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 /* ─── Constants ─── */
 
@@ -265,6 +266,8 @@ function LoadingSkeleton() {
 /* ─── Main Page ─── */
 
 export default function AdminTagsPage() {
+  useMobileHeader({ variant: 'compact', title: 'タグ' })
+
   const queryClient = useQueryClient()
   const [showCreateForm, setShowCreateForm] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)

--- a/packages/web/src/app/routes/admin-workbook-edit.tsx
+++ b/packages/web/src/app/routes/admin-workbook-edit.tsx
@@ -25,6 +25,7 @@ import type {
   Tag,
 } from '@/types'
 import type { ConfidenceLevel } from '@/lib/confidence-config'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 interface SetFormData {
   title: string
@@ -248,6 +249,12 @@ export default function AdminWorkbookEditPage() {
   const queryClient = useQueryClient()
   const isNew = id === 'new'
   const tipsModal = useModal()
+
+  useMobileHeader({
+    variant: 'compact',
+    title: isNew ? '問題集を作成' : '問題集を編集',
+    backTo: '/admin/workbooks',
+  })
 
   const [setForm, setSetForm] = useState<SetFormData>({
     title: '',

--- a/packages/web/src/app/routes/admin-workbooks.tsx
+++ b/packages/web/src/app/routes/admin-workbooks.tsx
@@ -10,6 +10,7 @@ import {
   type ColumnDef,
 } from '@/components/shared/responsive-table'
 import type { ApiResponse, Workbook, Subject } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function DeleteConfirmation({
   title,
@@ -60,6 +61,8 @@ function LoadingSkeleton() {
 }
 
 export default function AdminWorkbooksPage() {
+  useMobileHeader({ variant: 'compact', title: '問題集' })
+
   const queryClient = useQueryClient()
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [mutationError, setMutationError] = useState<string | null>(null)

--- a/packages/web/src/app/routes/exam-result.tsx
+++ b/packages/web/src/app/routes/exam-result.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { ConfidenceSelector } from '@/components/shared/confidence-selector'
 import { AnimatedNumber } from '@/components/shared/animated-number'
 import { ChoiceTips } from '@/components/shared/choice-tips'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function ScoreSummary({
   result,
@@ -350,6 +351,12 @@ function QuestionReviewList({ results }: { results: SessionResult['results'] }) 
 }
 
 export default function ExamResultPage() {
+  useMobileHeader({
+    variant: 'compact',
+    title: '試験結果',
+    backTo: '/dashboard',
+  })
+
   const { workbookId } = useParams<{ workbookId: string }>()
   const location = useLocation()
   const navigate = useNavigate()

--- a/packages/web/src/app/routes/exam.tsx
+++ b/packages/web/src/app/routes/exam.tsx
@@ -23,6 +23,7 @@ import type {
 import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { MobileQuestionNav } from '@/components/shared/mobile-question-nav'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function ExamTimer() {
   const elapsedSec = useElapsedSec()
@@ -64,6 +65,8 @@ type CreateSessionResponse = ApiResponse<{
 type AnswerReceivedResponse = ApiResponse<{ received: true }>
 
 export default function ExamPage() {
+  useMobileHeader({ variant: 'hidden' })
+
   const { workbookId } = useParams<{ workbookId: string }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()

--- a/packages/web/src/app/routes/history-detail.tsx
+++ b/packages/web/src/app/routes/history-detail.tsx
@@ -9,6 +9,7 @@ import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { ConfidenceSelector } from '@/components/shared/confidence-selector'
 import { ChoiceTips } from '@/components/shared/choice-tips'
 import type { ApiResponse, SessionResult, ConfidenceLevel } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function SessionSummary({
   result,
@@ -263,6 +264,12 @@ function LoadingSkeleton() {
 }
 
 export default function HistoryDetailPage() {
+  useMobileHeader({
+    variant: 'compact',
+    title: '試験履歴',
+    backTo: '/stats',
+  })
+
   const { attemptId } = useParams<{ attemptId: string }>()
 
   const resultQuery = useQuery({

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -29,6 +29,7 @@ import { ConfidenceSelector } from '@/components/shared/confidence-selector'
 import { ChoiceTips } from '@/components/shared/choice-tips'
 import { confidenceLevels, noConfidenceConfig } from '@/lib/confidence-config'
 import { MobileQuestionNav } from '@/components/shared/mobile-question-nav'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function PracticeTimer() {
   const elapsedSec = useElapsedSec()
@@ -48,6 +49,8 @@ type CreateSessionResponse = ApiResponse<{
 }>
 
 export default function PracticePage() {
+  useMobileHeader({ variant: 'hidden' })
+
   const { workbookId } = useParams<{ workbookId: string }>()
   const navigate = useNavigate()
   const queryClient = useQueryClient()

--- a/packages/web/src/app/routes/stats.tsx
+++ b/packages/web/src/app/routes/stats.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveTable,
   type ColumnDef,
 } from '@/components/shared/responsive-table'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 import type {
   ApiResponse,
   Subject,
@@ -194,6 +195,8 @@ function HistoryFilterBar({
 const HISTORY_LIMIT = 20
 
 export default function HistoryPage() {
+  useMobileHeader({ variant: 'compact', title: '履歴' })
+
   const [page, setPage] = useState(1)
   const [subjectId, setSubjectId] = useState('')
   const [workbookId, setWorkbookId] = useState('')

--- a/packages/web/src/app/routes/subject-exams.tsx
+++ b/packages/web/src/app/routes/subject-exams.tsx
@@ -5,6 +5,7 @@ import { queryKeys } from '@/lib/query-keys'
 import { ErrorMessage } from '@/components/shared/error-message'
 import { StaggerChildren } from '@/components/shared/stagger-children'
 import type { ApiResponse, Subject, Workbook } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 function SubjectHeader({ subject }: { subject: Subject }) {
   return (
@@ -190,6 +191,14 @@ export default function SubjectExams() {
     enabled: !!subjectId,
   })
 
+  const subject = subjectQuery.data?.data
+
+  useMobileHeader({
+    variant: 'compact',
+    title: subject?.name,
+    backTo: '/dashboard',
+  })
+
   const isLoading = subjectQuery.isLoading || workbooksQuery.isLoading
   const error = subjectQuery.error || workbooksQuery.error
 
@@ -201,7 +210,6 @@ export default function SubjectExams() {
     return <ErrorMessage message={error.message} />
   }
 
-  const subject = subjectQuery.data?.data
   const workbooks = workbooksQuery.data?.data ?? []
 
   if (!subject) {

--- a/packages/web/src/app/routes/workbook-history.tsx
+++ b/packages/web/src/app/routes/workbook-history.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { StaggerChildren } from '@/components/shared/stagger-children'
 import type { ApiResponse, HistoryEntry, SessionResult } from '@/types'
+import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
 /* ─── Question Result (per question in expanded view) ─── */
 
@@ -234,6 +235,12 @@ const LIMIT = 20
 export default function WorkbookHistoryPage() {
   const { workbookId } = useParams<{ workbookId: string }>()
   const [page, setPage] = useState(1)
+
+  useMobileHeader({
+    variant: 'compact',
+    title: '履歴',
+    backTo: '/dashboard',
+  })
 
   const historyQuery = useQuery({
     queryKey: queryKeys.stats.history(page, { workbookId: workbookId! }),

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
-import { Outlet, Link, useLocation } from 'react-router'
-import { SignedIn, UserButton } from '@clerk/clerk-react'
+import { Outlet, useLocation } from 'react-router'
 import { useMobileDrawer } from '@/hooks/use-mobile-drawer'
 import { useSidebarContext } from './sidebar-context'
-import { HamburgerButton } from './hamburger-button'
 import { MobileDrawer } from './mobile-drawer'
+import { MobileHeader } from './mobile-header'
+import { MobileHeaderProvider } from './mobile-header-context'
 import { Sidebar } from './sidebar'
 import { SidebarProvider } from './sidebar-provider'
 import { MobileTabBar } from './mobile-tab-bar'
@@ -45,23 +45,11 @@ function AppLayoutInner() {
 
       <Sidebar />
 
-      <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur md:hidden">
-        <div className="flex h-12 items-center px-4">
-          <Link to="/dashboard" className="text-base font-bold">
-            Exam App
-          </Link>
-          <div className="ml-auto flex items-center gap-2">
-            <SignedIn>
-              <UserButton />
-            </SignedIn>
-            <HamburgerButton
-              ref={drawer.triggerRef}
-              isOpen={drawer.isOpen}
-              onClick={drawer.toggle}
-            />
-          </div>
-        </div>
-      </header>
+      <MobileHeader
+        drawerOpen={drawer.isOpen}
+        onDrawerToggle={drawer.toggle}
+        triggerRef={drawer.triggerRef}
+      />
 
       <main
         id="main-content"
@@ -88,7 +76,9 @@ function AppLayoutInner() {
 export function AppLayout() {
   return (
     <SidebarProvider>
-      <AppLayoutInner />
+      <MobileHeaderProvider>
+        <AppLayoutInner />
+      </MobileHeaderProvider>
     </SidebarProvider>
   )
 }

--- a/packages/web/src/components/layout/mobile-header-context.tsx
+++ b/packages/web/src/components/layout/mobile-header-context.tsx
@@ -1,0 +1,64 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type HeaderVariant = 'default' | 'compact' | 'hidden'
+
+export interface HeaderConfig {
+  variant?: HeaderVariant
+  title?: string
+  backTo?: string
+}
+
+interface ContextValue {
+  config: HeaderConfig
+  register: (next: HeaderConfig | null) => void
+}
+
+const MobileHeaderContext = createContext<ContextValue | null>(null)
+
+export function MobileHeaderProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<HeaderConfig>({})
+
+  const register = useCallback((next: HeaderConfig | null) => {
+    setConfig(next ?? {})
+  }, [])
+
+  const value = useMemo(() => ({ config, register }), [config, register])
+
+  return (
+    <MobileHeaderContext.Provider value={value}>
+      {children}
+    </MobileHeaderContext.Provider>
+  )
+}
+
+export function useMobileHeaderConfig(): HeaderConfig {
+  const ctx = useContext(MobileHeaderContext)
+  if (!ctx) {
+    throw new Error(
+      'useMobileHeaderConfig must be used within MobileHeaderProvider',
+    )
+  }
+  return ctx.config
+}
+
+export function useMobileHeader(config: HeaderConfig) {
+  const ctx = useContext(MobileHeaderContext)
+  if (!ctx) {
+    throw new Error('useMobileHeader must be used within MobileHeaderProvider')
+  }
+  const { register } = ctx
+  const { variant, title, backTo } = config
+
+  useEffect(() => {
+    register({ variant, title, backTo })
+    return () => register(null)
+  }, [register, variant, title, backTo])
+}

--- a/packages/web/src/components/layout/mobile-header.tsx
+++ b/packages/web/src/components/layout/mobile-header.tsx
@@ -1,0 +1,117 @@
+import { Link } from 'react-router'
+import { SignedIn, UserButton } from '@clerk/clerk-react'
+import type { Ref } from 'react'
+import { HamburgerButton } from './hamburger-button'
+import { StreakBadge } from './streak-badge'
+import { useMobileHeaderConfig } from './mobile-header-context'
+import { useGreeting } from '@/hooks/use-greeting'
+
+interface Props {
+  drawerOpen: boolean
+  onDrawerToggle: () => void
+  triggerRef: Ref<HTMLButtonElement>
+}
+
+function BackIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function Greeting() {
+  const { text, displayName } = useGreeting()
+  return (
+    <p className="min-w-0 truncate text-[15px] font-bold leading-tight">
+      {displayName ? `${text}、${displayName}さん` : text}
+    </p>
+  )
+}
+
+function CompactHeader({
+  title,
+  backTo,
+  drawerOpen,
+  onDrawerToggle,
+  triggerRef,
+}: {
+  title?: string
+  backTo?: string
+} & Props) {
+  return (
+    <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur md:hidden">
+      <div className="flex h-12 items-center gap-1 pl-1 pr-2">
+        {backTo ? (
+          <Link
+            to={backTo}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground active:bg-muted"
+            aria-label="戻る"
+          >
+            <BackIcon />
+          </Link>
+        ) : (
+          <span className="w-2" aria-hidden="true" />
+        )}
+        <h1 className="min-w-0 flex-1 truncate text-[15px] font-bold">
+          {title ?? ''}
+        </h1>
+        <div className="flex items-center gap-1">
+          <SignedIn>
+            <UserButton />
+          </SignedIn>
+          <HamburgerButton
+            ref={triggerRef}
+            isOpen={drawerOpen}
+            onClick={onDrawerToggle}
+          />
+        </div>
+      </div>
+    </header>
+  )
+}
+
+function DefaultHeader({
+  drawerOpen,
+  onDrawerToggle,
+  triggerRef,
+}: Props) {
+  return (
+    <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur md:hidden">
+      <div className="flex h-14 items-center gap-2 px-4">
+        <Greeting />
+        <div className="ml-auto flex items-center gap-2">
+          <StreakBadge />
+          <SignedIn>
+            <UserButton />
+          </SignedIn>
+          <HamburgerButton
+            ref={triggerRef}
+            isOpen={drawerOpen}
+            onClick={onDrawerToggle}
+          />
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export function MobileHeader(props: Props) {
+  const { variant = 'default', title, backTo } = useMobileHeaderConfig()
+
+  if (variant === 'hidden') return null
+  if (variant === 'compact') {
+    return <CompactHeader title={title} backTo={backTo} {...props} />
+  }
+  return <DefaultHeader {...props} />
+}

--- a/packages/web/src/components/layout/streak-badge.tsx
+++ b/packages/web/src/components/layout/streak-badge.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api-client'
+import { calculateStreakDays } from '@/lib/calculate-streak'
+import type { ApiResponse, HistoryEntry } from '@/types'
+
+function FlameIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M13.3 2.2c.3.7.2 1.5-.3 2.1l-1 1.3c-.8 1-1.2 2.3-1 3.6l.1.6c.2 1.1 1 2 2.1 2.3 1.4.3 2.7-.6 3-2 .1-.6 0-1.2-.3-1.7-.2-.4 0-.9.4-1.1.3-.1.7 0 .9.3 1.9 2.8 2.3 6.4.8 9.5a7.7 7.7 0 0 1-14-4.6c0-3.2 1.9-6 4.7-7.4l3.4-1.6c.4-.2.9 0 1.1.3l.1.4Z" />
+    </svg>
+  )
+}
+
+export function StreakBadge() {
+  const { data } = useQuery({
+    queryKey: ['streak-history'] as const,
+    queryFn: () =>
+      api.get<ApiResponse<HistoryEntry[]>>('/stats/history', {
+        page: '1',
+        limit: '100',
+      }),
+    staleTime: 1000 * 60 * 5,
+  })
+
+  const days = calculateStreakDays(
+    (data?.data ?? []).map((h) => h.startedAt),
+  )
+
+  if (days === 0) return null
+
+  return (
+    <Link
+      to="/stats"
+      className="group inline-flex items-center justify-center p-1 -m-1"
+      aria-label={`${days}日連続学習中。履歴を開く`}
+    >
+      <span className="inline-flex items-center gap-1 rounded-full bg-warning-muted px-2.5 py-1 text-xs font-bold text-warning-foreground motion-safe:transition-transform motion-safe:group-active:scale-95">
+        <FlameIcon />
+        <span className="tabular-nums">{days}</span>
+      </span>
+    </Link>
+  )
+}

--- a/packages/web/src/hooks/use-greeting.ts
+++ b/packages/web/src/hooks/use-greeting.ts
@@ -1,0 +1,26 @@
+import { useUser } from '@clerk/clerk-react'
+
+function getTimeGreeting(hour: number): string {
+  if (hour < 5) return 'こんばんは'
+  if (hour < 11) return 'おはよう'
+  if (hour < 18) return 'こんにちは'
+  return 'こんばんは'
+}
+
+export interface Greeting {
+  text: string
+  displayName: string | null
+}
+
+export function useGreeting(now: Date = new Date()): Greeting {
+  const { user, isLoaded } = useUser()
+  const text = getTimeGreeting(now.getHours())
+
+  if (!isLoaded) {
+    return { text, displayName: null }
+  }
+
+  const displayName =
+    user?.firstName ?? user?.username ?? user?.fullName ?? null
+  return { text, displayName }
+}

--- a/packages/web/src/lib/calculate-streak.ts
+++ b/packages/web/src/lib/calculate-streak.ts
@@ -1,0 +1,39 @@
+function ymdLocal(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function calculateStreakDays(
+  isoDates: ReadonlyArray<string>,
+  now: Date = new Date(),
+): number {
+  if (isoDates.length === 0) return 0
+
+  const daysSet = new Set(
+    isoDates.map((iso) => ymdLocal(new Date(iso))),
+  )
+
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  let cursor: Date
+  if (daysSet.has(ymdLocal(today))) {
+    cursor = today
+  } else if (daysSet.has(ymdLocal(yesterday))) {
+    cursor = yesterday
+  } else {
+    return 0
+  }
+
+  let count = 0
+  while (daysSet.has(ymdLocal(cursor))) {
+    count += 1
+    const next = new Date(cursor)
+    next.setDate(next.getDate() - 1)
+    cursor = next
+  }
+  return count
+}


### PR DESCRIPTION
## Summary

モバイル左上の "Exam App" 静的テキストを、画面コンテキストとユーザーのパーソナリティを出すヘッダーに刷新。

**Before:** 全画面で "Exam App" という文字列だけ表示されていて、情報密度が低く現在地もわからない。

**After (variant切替):**
- `/dashboard` — 時間帯挨拶 + 🔥連続学習日数 Pill + UserButton + ハンバーガー
- 詳細画面（科目 / 試験結果 / 履歴 / 管理 等）— ← 戻るボタン + 画面タイトル
- 試験・演習画面 — ヘッダー非表示（ボトムタブと同様、集中モード）

## 設計

- `useMobileHeader({ variant, title, backTo })` を各ルートの冒頭で呼んで宣言
- `MobileHeaderProvider` が config を state 管理、`<MobileHeader />` が variant ごとに切替
- Streak は既存 `/stats/history` を `limit=100` で取得し、`calculateStreakDays` でクライアント側算出（サーバー API 追加なし、query key は `['streak-history']` で dashboard のキャッシュと分離）
- `useGreeting()` は時間帯 + Clerk `user.firstName` で挨拶を組み立て

## 変更ファイル

**新規 (5)**
- `components/layout/mobile-header-context.tsx`
- `components/layout/mobile-header.tsx`
- `components/layout/streak-badge.tsx`
- `hooks/use-greeting.ts`
- `lib/calculate-streak.ts`

**変更 (13)** — `app-layout.tsx` + 各ルート 12 ファイルに `useMobileHeader()` を追加

## Test plan

- [ ] モバイル表示で `/dashboard` を開き、挨拶（時間帯で変化）と UserButton・ハンバーガーが表示される
- [ ] 連続学習実績があれば 🔥N Pill が表示され、タップで `/stats` に遷移する（実績なしなら非表示）
- [ ] 科目別試験一覧（`/exams/:id`）で ← 戻る + 科目名が表示され、← タップで `/dashboard` に戻る
- [ ] 試験画面（`/exam/:id`）、演習画面（`/practice/:id`）でモバイルヘッダーが非表示
- [ ] 試験結果（`/exam/:id/result`）で ← + "試験結果" が出る
- [ ] `/stats`、`/workbooks/:id/history`、`/stats/history/:attemptId`、admin 各画面でそれぞれ適切なタイトルが出る
- [ ] 挨拶の時間帯分岐（5:00 / 11:00 / 18:00）がローカルタイムで切り替わる
- [ ] デスクトップ（md以上）ではモバイルヘッダーが完全に非表示で、既存サイドバーのみ表示
- [ ] 日をまたいで学習した場合に Streak 日数が正しく増加する