### PR TITLE
fix(web): デプロイ更新でチャンクが 404 のときに自動リロード

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,20 @@ import { createRoot } from 'react-dom/client'
 import { Root } from './app/root'
 import './styles/globals.css'
 
+const PRELOAD_RELOAD_KEY = 'vite-preload-reloaded-at'
+const PRELOAD_RELOAD_COOLDOWN_MS = 10_000
+
+window.addEventListener('vite:preloadError', (event) => {
+  const now = Date.now()
+  const last = Number(sessionStorage.getItem(PRELOAD_RELOAD_KEY) ?? '0')
+  if (now - last < PRELOAD_RELOAD_COOLDOWN_MS) {
+    console.error('vite:preloadError retry aborted:', event)
+    return
+  }
+  sessionStorage.setItem(PRELOAD_RELOAD_KEY, String(now))
+  window.location.reload()
+})
+
 const rootElement = document.getElementById('root')
 if (!rootElement) {
   throw new Error('Root element not found')


### PR DESCRIPTION
## Summary

Cloudflare Pages に新ビルドがデプロイされると、古い hash の JS チャンクが CDN から消えます。ユーザーが開きっぱなしのタブは古い \`index.html\` を持っているので、そこから lazy import を走らせた瞬間に 404 を踏み、"Failed to fetch dynamically imported module" エラーでページが死にます。

Vite が提供する \`vite:preloadError\` イベントを捕まえて自動リロードすることで、ユーザーが気付かないうちに回復できるようにします。

## 実装

\`packages/web/src/main.tsx\` に以下を追加：

- \`window.addEventListener('vite:preloadError', ...)\` で発火を拾う
- \`sessionStorage\` に前回 reload のタイムスタンプを保存
- 10 秒以内の再発動は諦めて \`console.error\` のみ（壊れたデプロイで無限リロードするのを防ぐ）
- それ以外は \`window.location.reload()\` で新しい \`index.html\` + 現行 hash を取得

## 再現条件（参考）

1. ユーザーがアプリを開く（ビルド A）
2. タブを閉じずに放置
3. 新しいデプロイが走る（ビルド B）
4. ユーザーがナビゲーション（例: \`/practice/:workbookId\` へ遷移）
5. lazy import でビルド A の hash を取りにいき 404

このフィックスが入ると 4 で自動リロードされてビルド B に切り替わります。

## Test plan

- [ ] dev サーバーで動作が従来通り（エラーが出ないケースで不要なリロードが発生しない）
- [ ] 本番デプロイ後、dev tools で \`window.dispatchEvent(new Event('vite:preloadError'))\` を発火させるとページがリロードされる
- [ ] 10 秒以内に2回発火した場合、2回目はリロードされずコンソールにエラーが出る
- [ ] 新デプロイ後に古いタブから遷移するシナリオで、エラー画面に落ちずに自動回復する