### PR TITLE
feat: 答え合わせ後に自信度を前回値+正誤から自動更新

### DIFF
--- a/packages/server/src/api/routes/sessions.ts
+++ b/packages/server/src/api/routes/sessions.ts
@@ -460,9 +460,8 @@ app.post('/:id/answers', async (c) => {
       eq(questionConfidence.questionId, body.questionId),
     ),
   })
-  const resolvedConfidenceLevel = isCorrect
-    ? (existingConfidence?.level ?? 0)
-    : 1
+  const previousConfidenceLevel = existingConfidence?.level ?? 0
+  const resolvedConfidenceLevel = isCorrect ? previousConfidenceLevel : 1
 
   if (!isCorrect) {
     c.executionCtx.waitUntil(
@@ -496,6 +495,7 @@ app.post('/:id/answers', async (c) => {
         isCorrect,
         explanation: snapshot.explanation,
         confidenceLevel: resolvedConfidenceLevel,
+        previousConfidenceLevel,
         choices: snapshot.choices.map(
           (ch: {
             id: string

--- a/packages/web/src/app/routes/practice.tsx
+++ b/packages/web/src/app/routes/practice.tsx
@@ -27,7 +27,12 @@ import { MarkdownRenderer } from '@/components/shared/markdown-renderer'
 import { LoadingSpinner } from '@/components/shared/loading-spinner'
 import { ConfidenceSelector } from '@/components/shared/confidence-selector'
 import { ChoiceTips } from '@/components/shared/choice-tips'
-import { confidenceLevels, noConfidenceConfig } from '@/lib/confidence-config'
+import {
+  confidenceLevels,
+  getConfidenceConfig,
+  noConfidenceConfig,
+} from '@/lib/confidence-config'
+import { calculateAutoConfidence } from '@/lib/confidence-auto'
 import { MobileQuestionNav } from '@/components/shared/mobile-question-nav'
 import { useMobileHeader } from '@/components/layout/mobile-header-context'
 
@@ -37,6 +42,47 @@ function PracticeTimer() {
     <span className="rounded-lg bg-muted px-3 py-1 font-mono text-sm tabular-nums">
       {formatElapsed(elapsedSec)}
     </span>
+  )
+}
+
+function AutoConfidenceNotice({
+  fromLevel,
+  toLevel,
+}: {
+  fromLevel: ConfidenceLevel
+  toLevel: ConfidenceLevel
+}) {
+  const fromConfig = getConfidenceConfig(fromLevel) ?? noConfidenceConfig
+  const toConfig = getConfidenceConfig(toLevel) ?? noConfidenceConfig
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground motion-safe:motion-preset-fade motion-safe:motion-duration-200"
+    >
+      <span className="font-medium">自動更新</span>
+      <span
+        className={`rounded-md px-2 py-0.5 ${fromConfig.bgClass} ${fromConfig.textClass}`}
+      >
+        {fromConfig.label}
+      </span>
+      <svg
+        aria-hidden="true"
+        className="h-3.5 w-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M13 6l6 6-6 6" />
+      </svg>
+      <span
+        className={`rounded-md px-2 py-0.5 ${toConfig.bgClass} ${toConfig.textClass}`}
+      >
+        {toConfig.label}
+      </span>
+      <span className="text-[11px]">下のボタンで変更できます</span>
+    </div>
   )
 }
 
@@ -74,12 +120,22 @@ export default function PracticePage() {
   const [answerState, setAnswerState] = useState<{
     feedback: AnswerFeedback | null
     confidenceLevel: ConfidenceLevel
-  }>({ feedback: null, confidenceLevel: 0 })
+    autoUpdatedFrom: ConfidenceLevel | null
+  }>({ feedback: null, confidenceLevel: 0, autoUpdatedFrom: null })
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const { feedback, confidenceLevel } = answerState
+  const { feedback, confidenceLevel, autoUpdatedFrom } = answerState
   const questionStartTime = useRef<number>(Date.now())
-  const feedbackCache = useRef<Record<number, { feedback: AnswerFeedback | null; confidenceLevel: ConfidenceLevel }>>({})
+  const feedbackCache = useRef<
+    Record<
+      number,
+      {
+        feedback: AnswerFeedback | null
+        confidenceLevel: ConfidenceLevel
+        autoUpdatedFrom: ConfidenceLevel | null
+      }
+    >
+  >({})
 
   const location = useLocation()
   const [isConfirmed, setIsConfirmed] = useState(false)
@@ -251,7 +307,13 @@ export default function PracticePage() {
       const stored = answers[currentIndex]
       setSelectedChoiceIds(stored ?? question.selectedChoiceIds ?? [])
       const cached = feedbackCache.current[currentIndex]
-      setAnswerState(cached ?? { feedback: null, confidenceLevel: 0 })
+      setAnswerState(
+        cached ?? {
+          feedback: null,
+          confidenceLevel: 0,
+          autoUpdatedFrom: null,
+        },
+      )
       questionStartTime.current = Date.now()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -298,9 +360,37 @@ export default function PracticePage() {
       )
 
       if (response.data) {
+        const previousLevel =
+          response.data.previousConfidenceLevel as ConfidenceLevel
+        const autoLevel = calculateAutoConfidence(
+          previousLevel,
+          response.data.isCorrect,
+        )
+        const didChange = autoLevel !== previousLevel
+
+        if (didChange && response.data.isCorrect) {
+          api
+            .put<ApiResponse<{ questionId: string; level: number }>>(
+              '/confidence',
+              { questionId: question.questionId, level: autoLevel },
+            )
+            .catch(() => {})
+          queryClient.setQueriesData<ApiResponse<Record<string, number>>>(
+            { queryKey: ['confidence', 'batch'] },
+            (old) => {
+              if (!old?.data) return old
+              return {
+                ...old,
+                data: { ...old.data, [question.questionId]: autoLevel },
+              }
+            },
+          )
+        }
+
         const nextState = {
           feedback: response.data,
-          confidenceLevel: response.data.confidenceLevel as ConfidenceLevel,
+          confidenceLevel: autoLevel,
+          autoUpdatedFrom: didChange ? previousLevel : null,
         }
         setAnswerState(nextState)
         feedbackCache.current[currentIndex] = nextState
@@ -322,6 +412,7 @@ export default function PracticePage() {
     recordQuestionTime,
     setAnswer,
     setAnswerStatus,
+    queryClient,
   ])
 
   const handleNavigate = useCallback(
@@ -854,13 +945,23 @@ export default function PracticePage() {
                   <MarkdownRenderer content={feedback.explanation} />
                 </div>
               )}
-              <div className="mt-3 border-t border-current/10 pt-3">
+              <div className="mt-3 space-y-2 border-t border-current/10 pt-3">
+                {autoUpdatedFrom !== null && (
+                  <AutoConfidenceNotice
+                    fromLevel={autoUpdatedFrom}
+                    toLevel={confidenceLevel}
+                  />
+                )}
                 <ConfidenceSelector
                   questionId={question.questionId}
                   currentLevel={confidenceLevel}
                   onLevelChange={(level) =>
                     setAnswerState((prev) => {
-                      const next = { ...prev, confidenceLevel: level }
+                      const next = {
+                        ...prev,
+                        confidenceLevel: level,
+                        autoUpdatedFrom: null,
+                      }
                       if (next.feedback) {
                         feedbackCache.current[currentIndex] = next
                       }

--- a/packages/web/src/lib/confidence-auto.ts
+++ b/packages/web/src/lib/confidence-auto.ts
@@ -1,0 +1,10 @@
+import type { ConfidenceLevel } from './confidence-config'
+
+export function calculateAutoConfidence(
+  previousLevel: ConfidenceLevel,
+  isCorrect: boolean,
+): ConfidenceLevel {
+  if (!isCorrect) return 1
+  if (previousLevel === 0) return 2
+  return Math.min(4, previousLevel + 1) as ConfidenceLevel
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -122,6 +122,7 @@ export interface AnswerFeedback {
   isCorrect: boolean
   explanation: string | null
   confidenceLevel: number
+  previousConfidenceLevel: number
   choices: Array<{
     id: string
     isCorrect: boolean


### PR DESCRIPTION
## Summary
- 答え合わせ後、前回の自信度と正誤から新しい自信度を自動的に振り分けるようにする
  - 正解 → +1（最大4、未設定なら2: やや不安）
  - 不正解 → 1（自信なし）
- 振り分け結果は UI 側で永続化され、ユーザーは引き続き ConfidenceSelector で自由に変更可能
- 自動更新が走った場合は ConfidenceSelector の上にバナー（「自動更新: 自信なし → やや不安」）を表示。色だけに頼らずラベル付きで提示し、`role=\"status\" aria-live=\"polite\"` でスクリーンリーダーにも通知

## 実装メモ
- 振り分けロジックは `packages/web/src/lib/confidence-auto.ts` に純関数として切り出し
- サーバー側の既存「不正解時 waitUntil で 1 に降格」ロジックは温存し、追加で `previousConfidenceLevel` をレスポンスに含めることで UI が before/after を判定できるようにした
- 正解時の昇格のみ UI から `PUT /confidence` を発火（`['confidence', 'batch']` キャッシュも楽観更新）
- ユーザーが ConfidenceSelector を操作すると `autoUpdatedFrom` が null になり通知は消える
- `feedbackCache` にも `autoUpdatedFrom` を保存するため、別の問題から戻ってきても通知が復元される

## Test plan
- [ ] 自信度未設定の問題に正解 → 「やや不安」に自動更新され、バナーが表示される
- [ ] 自信度「やや不安」の問題に正解 → 「まあまあ」に自動更新され、バナーが表示される
- [ ] 自信度「完璧」の問題に正解 → 変化なし、バナー非表示
- [ ] 自信度「やや不安」の問題に不正解 → 「自信なし」に降格され、バナーが表示される
- [ ] 自信度「自信なし」の問題に不正解 → 変化なし、バナー非表示
- [ ] バナー表示中に ConfidenceSelector で別の値を選ぶ → バナーが消える
- [ ] バナー表示中に次の問題へ進む → 戻ってくるとバナーが再表示される
- [ ] 答え合わせ後に問題集をリロードしても、振り分け結果が永続化されている（DB 更新が反映）